### PR TITLE
 Fix wrongly cased header file name

### DIFF
--- a/src/host/os_uuid.c
+++ b/src/host/os_uuid.c
@@ -7,7 +7,7 @@
 #include "premake.h"
 
 #if PLATFORM_WINDOWS
-#include <Objbase.h>
+#include <objbase.h>
 #endif
 
 


### PR DESCRIPTION
 Case sensitivity matters when trying to compile on a case-sensitive file
 system, i.e. when cross-compiling to windows on Linux.
