### PR TITLE
Added premake.make.undefine = { "TARGET" } to genie

### DIFF
--- a/build/gmake.darwin/genie.make
+++ b/build/gmake.darwin/genie.make
@@ -3,6 +3,8 @@ ifndef config
   config=release
 endif
 
+override undefine TARGET
+
 ifndef verbose
   SILENT = @
 endif

--- a/build/gmake.linux/genie.make
+++ b/build/gmake.linux/genie.make
@@ -3,6 +3,8 @@ ifndef config
   config=release
 endif
 
+override undefine TARGET
+
 ifndef verbose
   SILENT = @
 endif

--- a/build/gmake.windows/genie.make
+++ b/build/gmake.windows/genie.make
@@ -3,6 +3,8 @@ ifndef config
   config=release
 endif
 
+override undefine TARGET
+
 ifndef verbose
   SILENT = @
 endif

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -7,7 +7,8 @@
 -- default when folks build using the makefile. That way they don't have to
 -- worry about the /scripts argument and all that.
 --
-
+	premake.make.undefine = { "TARGET" }
+	
 	solution "genie"
 		configurations {
 			"Release",


### PR DESCRIPTION
We are using TARGET in our project main makefile, and guess others too, so this could help making genie out of main make file under proper name, otherwise it will get name of propagated TARGET