### PR TITLE
Add os.ticks() function for more precise tick counter.

### DIFF
--- a/build/gmake.darwin/genie.make
+++ b/build/gmake.darwin/genie.make
@@ -66,6 +66,7 @@ ifeq ($(config),release)
 	$(OBJDIR)/src/host/premake.o \
 	$(OBJDIR)/src/host/os_getcwd.o \
 	$(OBJDIR)/src/host/premake_main.o \
+	$(OBJDIR)/src/host/os_ticks.o \
 	$(OBJDIR)/src/host/string_hash.o \
 	$(OBJDIR)/src/host/os_is64bit.o \
 	$(OBJDIR)/src/host/os_match.o \
@@ -143,6 +144,7 @@ ifeq ($(config),debug)
 	$(OBJDIR)/src/host/premake.o \
 	$(OBJDIR)/src/host/os_getcwd.o \
 	$(OBJDIR)/src/host/premake_main.o \
+	$(OBJDIR)/src/host/os_ticks.o \
 	$(OBJDIR)/src/host/string_hash.o \
 	$(OBJDIR)/src/host/os_is64bit.o \
 	$(OBJDIR)/src/host/os_match.o \
@@ -220,6 +222,7 @@ ifeq ($(config),releaseuniv32)
 	$(OBJDIR)/src/host/premake.o \
 	$(OBJDIR)/src/host/os_getcwd.o \
 	$(OBJDIR)/src/host/premake_main.o \
+	$(OBJDIR)/src/host/os_ticks.o \
 	$(OBJDIR)/src/host/string_hash.o \
 	$(OBJDIR)/src/host/os_is64bit.o \
 	$(OBJDIR)/src/host/os_match.o \
@@ -297,6 +300,7 @@ ifeq ($(config),debuguniv32)
 	$(OBJDIR)/src/host/premake.o \
 	$(OBJDIR)/src/host/os_getcwd.o \
 	$(OBJDIR)/src/host/premake_main.o \
+	$(OBJDIR)/src/host/os_ticks.o \
 	$(OBJDIR)/src/host/string_hash.o \
 	$(OBJDIR)/src/host/os_is64bit.o \
 	$(OBJDIR)/src/host/os_match.o \
@@ -347,8 +351,8 @@ endif
 
 OBJDIRS := \
 	$(OBJDIR) \
-	$(OBJDIR)/src/host/lua-5.3.0/src \
 	$(OBJDIR)/src/host \
+	$(OBJDIR)/src/host/lua-5.3.0/src \
 
 RESOURCES := \
 
@@ -443,6 +447,10 @@ $(OBJDIR)/src/host/os_getcwd.o: ../../src/host/os_getcwd.c
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF $(@:%.o=%.d) -c "$<"
 
 $(OBJDIR)/src/host/premake_main.o: ../../src/host/premake_main.c
+	@echo $(notdir $<)
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF $(@:%.o=%.d) -c "$<"
+
+$(OBJDIR)/src/host/os_ticks.o: ../../src/host/os_ticks.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF $(@:%.o=%.d) -c "$<"
 

--- a/build/gmake.linux/genie.make
+++ b/build/gmake.linux/genie.make
@@ -66,6 +66,7 @@ ifeq ($(config),release)
 	$(OBJDIR)/src/host/premake.o \
 	$(OBJDIR)/src/host/os_getcwd.o \
 	$(OBJDIR)/src/host/premake_main.o \
+	$(OBJDIR)/src/host/os_ticks.o \
 	$(OBJDIR)/src/host/string_hash.o \
 	$(OBJDIR)/src/host/os_is64bit.o \
 	$(OBJDIR)/src/host/os_match.o \
@@ -143,6 +144,7 @@ ifeq ($(config),debug)
 	$(OBJDIR)/src/host/premake.o \
 	$(OBJDIR)/src/host/os_getcwd.o \
 	$(OBJDIR)/src/host/premake_main.o \
+	$(OBJDIR)/src/host/os_ticks.o \
 	$(OBJDIR)/src/host/string_hash.o \
 	$(OBJDIR)/src/host/os_is64bit.o \
 	$(OBJDIR)/src/host/os_match.o \
@@ -289,6 +291,10 @@ $(OBJDIR)/src/host/os_getcwd.o: ../../src/host/os_getcwd.c
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF $(@:%.o=%.d) -c "$<"
 
 $(OBJDIR)/src/host/premake_main.o: ../../src/host/premake_main.c
+	@echo $(notdir $<)
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF $(@:%.o=%.d) -c "$<"
+
+$(OBJDIR)/src/host/os_ticks.o: ../../src/host/os_ticks.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF $(@:%.o=%.d) -c "$<"
 

--- a/build/gmake.windows/genie.make
+++ b/build/gmake.windows/genie.make
@@ -66,6 +66,7 @@ ifeq ($(config),release)
 	$(OBJDIR)/src/host/premake.o \
 	$(OBJDIR)/src/host/os_getcwd.o \
 	$(OBJDIR)/src/host/premake_main.o \
+	$(OBJDIR)/src/host/os_ticks.o \
 	$(OBJDIR)/src/host/string_hash.o \
 	$(OBJDIR)/src/host/os_is64bit.o \
 	$(OBJDIR)/src/host/os_match.o \
@@ -143,6 +144,7 @@ ifeq ($(config),debug)
 	$(OBJDIR)/src/host/premake.o \
 	$(OBJDIR)/src/host/os_getcwd.o \
 	$(OBJDIR)/src/host/premake_main.o \
+	$(OBJDIR)/src/host/os_ticks.o \
 	$(OBJDIR)/src/host/string_hash.o \
 	$(OBJDIR)/src/host/os_is64bit.o \
 	$(OBJDIR)/src/host/os_match.o \
@@ -289,6 +291,10 @@ $(OBJDIR)/src/host/os_getcwd.o: ../../src/host/os_getcwd.c
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF $(@:%.o=%.d) -c "$<"
 
 $(OBJDIR)/src/host/premake_main.o: ../../src/host/premake_main.c
+	@echo $(notdir $<)
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF $(@:%.o=%.d) -c "$<"
+
+$(OBJDIR)/src/host/os_ticks.o: ../../src/host/os_ticks.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF $(@:%.o=%.d) -c "$<"
 

--- a/src/host/os_ticks.c
+++ b/src/host/os_ticks.c
@@ -1,0 +1,41 @@
+/**
+ * \file   os_ticks.c
+ * \brief  Return the system tick counter (in microsecond units).
+ */
+
+#include <stdlib.h>
+#include "premake.h"
+
+// Epochs used by Windows and Unix time APIs.  These adjustments,
+// when added to the time value returned by the OS, will yield
+// the number of microsecond intervals since Jan 1, year 1.
+#define TICK_EPOCH_WINDOWS ((lua_Integer)0x0701ce1722770000)
+#define TICK_EPOCH_UNIX    ((lua_Integer)0x00dcbffeff2bc000)
+
+#define TICKS_PER_SECOND   ((lua_Integer)1000000)
+
+int os_ticks(lua_State* L)
+{
+    lua_Integer ticks = 0;
+
+#if PLATFORM_WINDOWS
+    FILETIME fileTimeUtc;
+    GetSystemTimeAsFileTime(&fileTimeUtc);
+    ticks =
+        TICK_EPOCH_WINDOWS
+        + ((lua_Integer)fileTimeUtc.dwHighDateTime << 32
+            | (lua_Integer)fileTimeUtc.dwLowDateTime);
+    ticks /= (lua_Integer)10;
+#else
+    struct timeval tp;
+    if (gettimeofday(&tp, NULL) == 0) {
+        ticks = 
+            TICK_EPOCH_UNIX
+            + (lua_Integer)tp.tv_sec * TICKS_PER_SECOND
+            + (lua_Integer)tp.tv_usec;
+    }
+#endif
+
+    lua_pushinteger(L, ticks);
+    return 1;
+}

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -56,6 +56,7 @@ static const luaL_Reg os_functions[] = {
 	{ "pathsearch",  os_pathsearch  },
 	{ "rmdir",       os_rmdir       },
 	{ "stat",        os_stat        },
+	{ "ticks",       os_ticks       },
 	{ "uuid",        os_uuid        },
 	{ NULL, NULL }
 };

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -33,6 +33,7 @@
 #include <windows.h>
 #else
 #include <unistd.h>
+#include <sys/time.h>
 #endif
 
 
@@ -63,6 +64,7 @@ int os_mkdir(lua_State* L);
 int os_pathsearch(lua_State* L);
 int os_rmdir(lua_State* L);
 int os_stat(lua_State* L);
+int os_ticks(lua_State* L);
 int os_uuid(lua_State* L);
 int string_endswith(lua_State* L);
 


### PR DESCRIPTION
The function returns the system clock in units of microseconds. The
epoch is January 1, year 1.  Useful for benchmarking code.

Note that I'm unable to test this on OSX, so you should probably do that before accepting this pull request.