### PR TITLE
Bug fix on vs201x actions for OutDir and IntDir

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -122,13 +122,13 @@
 
 				_p(1,'<PropertyGroup '..if_config_and_platform() ..'>', premake.esc(cfginfo.name))
 
-				_p(2,'<OutDir>%s\\</OutDir>', premake.esc(target.directory))
+				_p(2,'<OutDir>%s</OutDir>', premake.esc(target.directory))
 
 				if cfg.platform == "Xbox360" then
 					_p(2,'<OutputFile>$(OutDir)%s</OutputFile>', premake.esc(target.name))
 				end
 
-				_p(2,'<IntDir>%s\\</IntDir>', premake.esc(cfg.objectsdir))
+				_p(2,'<IntDir>%s</IntDir>', premake.esc(cfg.objectsdir))
 				_p(2,'<TargetName>%s</TargetName>', premake.esc(path.getbasename(target.name)))
 				_p(2,'<TargetExt>%s</TargetExt>', premake.esc(path.getextension(target.name)))
 


### PR DESCRIPTION
Fix a potential problem when either "target.directory" or "cfg.objectsdir" is an empty string (occurs when cfg.targetdir == cfg.location).

When either of them is empty will lead to
```xml
<OutDir>\</OutDir>
```
```xml
<IntDir>\</IntDir>
```
in the output vcxproj file.

In Windows \ means the root of the current driver and hence the build outputs (.lib, .dll, .exe) are be placed incorrectly at the root of the current driver but not in the same folder as the vcxproj file.

That's why [vs200x_vcproj.lua](https://github.com/bkaradzic/genie/blob/master/src/actions/vstudio/vs200x_vcproj.lua#L66) does not append any \ in the OutputDirectory and IntermediateDirectory attribute.