### PR TITLE
Allow explicit selection of debug or release runtime linking

### DIFF
--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -166,6 +166,8 @@
 					Optimize = 1,
 					OptimizeSize = 1,
 					OptimizeSpeed = 1,
+					DebugRuntime = 1,
+					ReleaseRuntime = 1,
 					SEH = 1,
 					StaticATL = 1,
 					StaticRuntime = 1,

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -18,14 +18,25 @@
 --
 
 	function premake.config.isdebugbuild(cfg)
+		-- If any of the specific runtime flags are set
+		if cfg.flags.DebugRuntime then
+			return true
+		end
+
+		if cfg.flags.ReleaseRuntime then
+			return false
+		end
+
 		-- If any of the optimize flags are set, it's a release a build
 		if cfg.flags.Optimize or cfg.flags.OptimizeSize or cfg.flags.OptimizeSpeed then
 			return false
 		end
+
 		-- If symbols are not defined, it's a release build
 		if not cfg.flags.Symbols then
 			return false
 		end
+
 		return true
 	end
 


### PR DESCRIPTION
DebugRuntime or ReleaseRuntime flags can be set to override the
automated choice of a runtime library.

Optimally these would not be flags because they are mutually exclusive,
but that doesn't seem worth the necessary architectural shifts at the
moment (unless there is a simple solution I haven't found).