### PR TITLE
Adding Green Hills Software compiler support

### DIFF
--- a/src/_manifest.lua
+++ b/src/_manifest.lua
@@ -28,6 +28,7 @@
 		"base/inspect.lua",
 		"tools/dotnet.lua",
 		"tools/gcc.lua",
+		"tools/ghs.lua",
 		"tools/msc.lua",
 		"tools/ow.lua",
 		"tools/snc.lua",

--- a/src/actions/make/_make.lua
+++ b/src/actions/make/_make.lua
@@ -137,7 +137,7 @@
 		valid_languages = { "C", "C++", "C#" },
 
 		valid_tools     = {
-			cc     = { "gcc" },
+			cc     = { "gcc", "ghs" },
 			dotnet = { "mono", "msnet", "pnet" },
 		},
 

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -384,24 +384,11 @@
 		_p('  LIBS      += $(LDDEPS)%s', make.list(cc.getlinkflags(cfg)))
 
 		if cfg.kind == "StaticLib" then
-			if cfg.platform:startswith("Universal") then
-				_p('  LINKCMD    = libtool -o $(TARGET)')
+			if (not prj.options.ArchiveSplit) then
+				_p('  LINKCMD    = $(AR) %s $(TARGET)', make.list(cc.getarchiveflags(prj, cfg, false)))
 			else
-				if (not prj.options.ArchiveSplit) then
-					if cc.llvm then
-						_p('  LINKCMD    = $(AR) rcs $(TARGET)')
-					else
-						_p('  LINKCMD    = $(AR) -rcs $(TARGET)')
-					end
-				else
-					if cc.llvm then
-						_p('  LINKCMD    = $(AR) qc $(TARGET)')
-						_p('  LINKCMD_NDX= $(AR) cs $(TARGET)')
-					else
-						_p('  LINKCMD    = $(AR) -qc $(TARGET)')
-						_p('  LINKCMD_NDX= $(AR) -cs $(TARGET)')
-					end
-				end
+				_p('  LINKCMD    = $(AR) %s $(TARGET)', make.list(cc.getarchiveflags(prj, cfg, false)))
+				_p('  LINKCMD_NDX= $(AR) %s $(TARGET)', make.list(cc.getarchiveflags(prj, cfg, true)))
 			end
 		else
 
@@ -465,7 +452,7 @@
 		_p('\t@echo $(notdir $<)')
 
 		local cmd = iif(prj.language == "C", "$(CC) -x c-header $(ALL_CFLAGS)", "$(CXX) -x c++-header $(ALL_CXXFLAGS)")
-		_p('\t$(SILENT) %s -MMD -MP $(DEFINES) $(INCLUDES) -o "$@" -MF "$(@:%%.gch=%%.d)" -c "$<"', cmd)
+		_p('\t$(SILENT) %s $(DEFINES) $(INCLUDES) -o "$@" -c "$<"', cmd)
 
 		_p('endif')
 		_p('')
@@ -491,7 +478,7 @@
 					_p('\t@echo $(notdir $<)')
 				end
 				if (path.isobjcfile(file)) then
-					_p('\t$(SILENT) $(CXX) $(ALL_OBJCFLAGS) $(FORCE_INCLUDE) -o "$@" -MF $(@:%%.o=%%.d) -c "$<"')
+					_p('\t$(SILENT) $(CXX) $(ALL_OBJCFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"')
 				else
 					cpp.buildcommand(path.iscfile(file) and not prj.options.ForceCPP, "o")
 				end
@@ -536,5 +523,5 @@
 
 	function cpp.buildcommand(iscfile, objext)
 		local flags = iif(iscfile, '$(CC) $(ALL_CFLAGS)', '$(CXX) $(ALL_CXXFLAGS)')
-		_p('\t$(SILENT) %s $(FORCE_INCLUDE) -o "$@" -MF $(@:%%.%s=%%.d) -c "$<"', flags, objext)
+		_p('\t$(SILENT) %s $(FORCE_INCLUDE) -o "$@" -c "$<"', flags, objext)
 	end

--- a/src/base/cmdline.lua
+++ b/src/base/cmdline.lua
@@ -17,6 +17,7 @@
 		allowed = {
 			{ "gcc", "GNU GCC (gcc/g++)" },
 			{ "ow",  "OpenWatcom"        },
+			{ "ghs", "Green Hills Software" },
 		}
 	}
 
@@ -73,7 +74,8 @@
 			{ "ps3",         "Playstation 3 (experimental)" },
 			{ "orbis",       "Playstation 4" },
 			{ "xbox360",     "Xbox 360 (experimental)" },
-			{ "ARM",         "ARM (Microsoft)" },
+			{ "ARM",         "ARM" },
+			{ "PowerPC",     "PowerPC" },
 		}
 	}
 	

--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -57,11 +57,15 @@
 			iscrosscompiler = true,
 			namestyle       = "windows",
 		},
+		PowerPC =
+		{
+			cfgsuffix       = "ppc",
+			iscrosscompiler = true,
+		},
 		ARM =
 		{
 			cfgsuffix       = "ARM",
 			iscrosscompiler = true,
-			namestyle       = "windows"
 		},
 		Orbis = 
 		{ 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -52,33 +52,36 @@
 	premake.gcc.platforms =
 	{
 		Native = {
-			cppflags = "-MMD",
+			cppflags = "-MMD -MP",
 		},
 		x32 = {
-			cppflags = "-MMD",
+			cppflags = "-MMD -MP",
 			flags    = "-m32",
 		},
 		x64 = {
-			cppflags = "-MMD",
+			cppflags = "-MMD -MP",
 			flags    = "-m64",
 		},
 		Universal = {
-			cppflags = "",
+			ar       = "libtool",
+			cppflags = "-MMD -MP",
 			flags    = "-arch i386 -arch x86_64 -arch ppc -arch ppc64",
 		},
 		Universal32 = {
-			cppflags = "",
+			ar       = "libtool",
+			cppflags = "-MMD -MP",
 			flags    = "-arch i386 -arch ppc",
 		},
 		Universal64 = {
-			cppflags = "",
+			ar       = "libtool",
+			cppflags = "-MMD -MP",
 			flags    = "-arch x86_64 -arch ppc64",
 		},
 		PS3 = {
 			cc         = "ppu-lv2-g++",
 			cxx        = "ppu-lv2-g++",
 			ar         = "ppu-lv2-ar",
-			cppflags   = "-MMD",
+			cppflags   = "-MMD -MP",
 		},
 		WiiDev = {
 			cppflags    = "-MMD -MP -I$(LIBOGC_INC) $(MACHDEP)",
@@ -210,6 +213,47 @@
 		return result
 	end
 
+
+
+--
+-- Get flags for passing to AR before the target is appended to the commandline
+--  prj: project
+--  cfg: configuration
+--  ndx: true if the final step of a split archive
+--
+
+	function premake.gcc.getarchiveflags(prj, cfg, ndx)
+		local result = {}
+		if cfg.platform:startswith("Universal") then
+				if prj.options.ArchiveSplit then
+					error("gcc tool 'Universal*' platforms do not support split archives")
+				end
+				table.insert(result, '-o')
+		else
+			if (not prj.options.ArchiveSplit) then
+				if llvm then
+					table.insert(result, 'rcs')
+				else
+					table.insert(result, '-rcs')
+				end
+			else
+				if llvm then
+					if (not ndx) then
+						table.insert(result, 'qc')
+					else
+						table.insert(result, 'cs')
+					end
+				else
+					if (not ndx) then
+						table.insert(result, '-qc')
+					else
+						table.insert(result, '-cs')
+					end
+				end
+			end
+		end
+		return result
+	end
 
 
 --

--- a/src/tools/ghs.lua
+++ b/src/tools/ghs.lua
@@ -1,0 +1,191 @@
+--
+-- ghs.lua
+-- Provides Green Hills Software-specific configuration strings.
+--
+
+	premake.ghs = { }
+	premake.ghs.namestyle = "PS3"
+
+
+--
+-- Set default tools
+--
+
+	premake.ghs.cc     = "ccppc"
+	premake.ghs.cxx    = "cxppc"
+	premake.ghs.ar     = "cxppc"
+	
+
+--
+-- Translation of Premake flags into GHS flags
+--
+
+	local cflags =
+	{
+		FatalWarnings  = "--quit_after_warnings",
+		Optimize       = "-Ogeneral",
+		OptimizeSize   = "-Osize",
+		OptimizeSpeed  = "-Ospeed",
+		Symbols        = "-g",
+	}
+
+	local cxxflags =
+	{
+		NoExceptions   = "--no_exceptions",
+		NoRTTI         = "--no_rtti",
+		UnsignedChar   = "--unsigned_chars",
+	}
+
+
+--
+-- Map platforms to flags
+--
+
+	premake.ghs.platforms =
+	{
+		Native = {
+			cppflags = "-MMD",
+		},
+		PowerPC = {
+			cc         = "ccppc",
+			cxx	       = "cxppc",
+			ar	       = "cxppc",
+			cppflags   = "-MMD",
+			arflags    = "-archive -o",
+		},
+		ARM = {
+			cc         = "ccarm",
+			cxx        = "cxarm",
+			ar         = "cxarm",
+			cppflags   = "-MMD",
+			arflags    = "-archive -o",
+		}
+	}
+
+	local platforms = premake.ghs.platforms
+
+
+--
+-- Returns a list of compiler flags, based on the supplied configuration.
+--
+
+	function premake.ghs.getcppflags(cfg)
+		local flags = { }
+		table.insert(flags, platforms[cfg.platform].cppflags)
+		return flags
+	end
+
+
+	function premake.ghs.getcflags(cfg)
+		local result = table.translate(cfg.flags, cflags)
+		table.insert(result, platforms[cfg.platform].flags)
+		return result
+	end
+
+
+	function premake.ghs.getcxxflags(cfg)
+		local result = table.translate(cfg.flags, cxxflags)
+		return result
+	end
+
+
+--
+-- Returns a list of linker flags, based on the supplied configuration.
+--
+
+	function premake.ghs.getldflags(cfg)
+		local result = { }
+		
+		local platform = platforms[cfg.platform]
+		table.insert(result, platform.flags)
+		table.insert(result, platform.ldflags)
+
+		return result
+	end
+
+
+--
+-- Return a list of library search paths. Technically part of LDFLAGS but need to
+-- be separated because of the way Visual Studio calls GCC for the PS3. See bug
+-- #1729227 for background on why library paths must be split.
+--
+
+	function premake.ghs.getlibdirflags(cfg)
+		local result = { }
+		for _, value in ipairs(premake.getlinks(cfg, "all", "directory")) do
+			table.insert(result, '-L' .. _MAKE.esc(value))
+		end
+		return result
+	end
+
+
+
+--
+-- This is poorly named: returns a list of linker flags for external
+-- (i.e. system, or non-sibling) libraries. See bug #1729227 for
+-- background on why the path must be split.
+--
+
+	function premake.ghs.getlinkflags(cfg)
+		local result = {}
+		for _, value in ipairs(premake.getlinks(cfg, "system", "name")) do
+			table.insert(result, '-lnk=' .. _MAKE.esc(value))
+		end
+		return result
+	end
+	
+--
+-- Get flags for passing to AR before the target is appended to the commandline
+--  prj: project
+--  cfg: configuration
+--  ndx: true if the final step of a split archive
+--
+
+	function premake.ghs.getarchiveflags(prj, cfg, ndx)
+		if prj.options.ArchiveSplit then
+			error("ghs tool does not support split archives")
+		end
+
+		local result = {}
+		local platform = platforms[cfg.platform]
+		table.insert(result, platform.arflags)
+		return result
+	end
+
+
+
+--
+-- Decorate defines for the GHS command line.
+--
+
+	function premake.ghs.getdefines(defines)
+		local result = { }
+		for _,def in ipairs(defines) do
+			table.insert(result, '-D' .. def)
+		end
+		return result
+	end
+
+
+
+--
+-- Decorate include file search paths for the GCC command line.
+--
+
+	function premake.ghs.getincludedirs(includedirs)
+		local result = { }
+		for _,dir in ipairs(includedirs) do
+			table.insert(result, "-I" .. _MAKE.esc(dir))
+		end
+		return result
+	end
+
+
+--
+-- Return platform specific project and configuration level
+-- makesettings blocks.
+--
+
+	function premake.ghs.getcfgsettings(cfg)
+		return platforms[cfg.platform].cfgsettings
+	end


### PR DESCRIPTION
make_cpp.lua
- Abstracted a bunch of gcc assumptions into the tool files such that
gcc and ghs make files can be generated. There is still room for future
improvement here (e.g. remove assumption of -c and -o flags where used)
- I'm not terribly pleased with the abstracted AR flags (now calls
getarchiveflags) due to interaction with the ArchiveSplit feature. It
needs to supports normal archiving, and the two phases of split
archiving.
- The explicit dependency file paths were removed when taking out the MF
flag, but they already matched the same '*.d' files names that gcc and
ghs would generate from the '*.o' so there should be no issue.

cmdline.lua
- New cc tool 'ghs' for Green Hills Software
- ARM platform setting is no longer Microsoft specific
- New PowerPC platform setting

globals.lua
- New PowerPC platform added
- ARM platform now lets the tool choose its namestyle

gcc.lua
- '-MP' compiler option is now defined by the gcc tool file (Make action
no longer assumes gcc)
- AR options are now defined by the tool file (Make action no longer
assumes gcc)
-- A user friendly error is printed if trying to mix ArchiveSplit with a
Universal platform (wasn't supported prior)

ghs.lua
- Added a new GHS tool with support for PowerPC (tested) and ARM
(untested) platforms.

manifest.lua
- Added the ghs.lua file