### PR TITLE
Precompiled headers improvement

### DIFF
--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -449,9 +449,13 @@
 	function cpp.pchrules(prj)
 		_p('ifneq (,$(PCH))')
 		_p('$(GCH): $(PCH)')
-		_p('\t@echo $(notdir $<)')
+		if prj.msgprecompile then
+			_p('\t@echo ' .. prj.msgprecompile)
+		else
+			_p('\t@echo $(notdir $<)')
+		end	
 
-		local cmd = iif(prj.language == "C", "$(CC) -x c-header $(ALL_CFLAGS)", "$(CXX) -x c++-header $(ALL_CXXFLAGS)")
+		local cmd = iif(prj.language == "C", "$(CC) $(ALL_CFLAGS) -x c-header", "$(CXX) $(ALL_CXXFLAGS) -x c++-header")
 		_p('\t$(SILENT) %s $(DEFINES) $(INCLUDES) -o "$@" -c "$<"', cmd)
 
 		_p('endif')

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -371,6 +371,12 @@
 			scope = "config",
 		},
 
+		msgprecompile =
+		{
+			kind  = "string",
+			scope = "config",
+		},
+
 		msgcompile_objc =
 		{
 			kind  = "string",


### PR DESCRIPTION
Placed -x c-header after flags, since those flags can contain -x parameter as well

Added msgprecompile for custom compile message for precompiled headers