### PR TITLE
Fixed solutionVersion for VS2015 and ToolsVersion for all VS201x

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -723,7 +723,7 @@
 			t = ' DefaultTargets="' .. targets .. '"'
 		end
 
-		_p('<Project%s ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">', t)
+		_p('<Project%s ToolsVersion="%s" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">', t, action.vstudio.toolsVersion)
 	end
 
 

--- a/src/actions/vstudio/vs2015.lua
+++ b/src/actions/vstudio/vs2015.lua
@@ -54,7 +54,7 @@
 		oncleantarget   = premake.vstudio.cleantarget,
 
 		vstudio = {
-			solutionVersion = "14",
+			solutionVersion = "12",
 			targetFramework = "4.5",
 			toolsVersion    = "14.0",
 			windowsTargetPlatformVersion = "8.1",


### PR DESCRIPTION
This fixes IncrediBuild under VS2015, otherwise projects are not recognized correctly.

light version of IncrediBuild is free for VS2015 
https://channel9.msdn.com/Shows/C9-GoingNative/GoingNative-45-Incredi-builds-with-IncrediBuild-free-in-Visual-Studio-2015