### PR TITLE
Xcode project improvements

### DIFF
--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -3,11 +3,9 @@
 -- Functions to generate the different sections of an Xcode project.
 -- Copyright (c) 2009-2011 Jason Perkins and the Premake project
 --
-
+	premake.xcode.parameters = { }
 	local xcode = premake.xcode
 	local tree  = premake.tree
-
-
 --
 -- Return the Xcode build category for a given file, based on the file extension.
 --
@@ -899,7 +897,13 @@
 				table.insert(flags, flag)
 			end
 		end
-		xcode.printlist(table.join(flags, cfg.buildoptions), 'OTHER_CFLAGS')
+
+		for _, val in ipairs(premake.xcode.parameters) do
+			_p(4, val ..';')
+		end
+
+		xcode.printlist(table.join(flags, cfg.buildoptions, cfg.buildoptions_c), 'OTHER_CFLAGS')
+		xcode.printlist(table.join(flags, cfg.buildoptions, cfg.buildoptions_cpp), 'OTHER_CPLUSPLUSFLAGS')
 
 		-- build list of "other" linked flags. All libraries that aren't frameworks
 		-- are listed here, so I don't have to try and figure out if they are ".a"


### PR DESCRIPTION
Here is example how to use it 
premake.xcode.parameters = { 'CLANG_CXX_LANGUAGE_STANDARD = "c++14"', 'CLANG_CXX_LIBRARY = "libc++"' }

buildoptions_c will be used on C files only and buildoptions_cpp on C++ projects only.

Solves issues #87 and #88 