### PR TITLE
Allow files to be marked as Visual C++ deployment content 

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -553,7 +553,8 @@
 				None = {},
 				ResourceCompile = {},
 				AppxManifest = {},
-				Image = {}
+				Image = {},
+				DeploymentContent = {}
 			}
 
 			local foundAppxManifest = false
@@ -566,14 +567,13 @@
 					end
 				elseif path.isresourcefile(file.name) then
 					table.insert(sortedfiles.ResourceCompile, file)
+				elseif path.isappxmanifest(file.name) then
+					foundAppxManifest = true
+					table.insert(sortedfiles.AppxManifest, file)
+				elseif file.flags and table.icontains(file.flags, "DeploymentContent") then
+					table.insert(sortedfiles.DeploymentContent, file)
 				else
-					local ext = path.getextension(file.name):lower()
-					if ext == ".appxmanifest" then
-						foundAppxManifest = true
-						table.insert(sortedfiles.AppxManifest, file)
-					else
-						table.insert(sortedfiles.None, file)
-					end
+					table.insert(sortedfiles.None, file)
 				end
 			end
 
@@ -613,6 +613,7 @@
 		vc2010.simplefilesgroup(prj, "ResourceCompile")
 		vc2010.simplefilesgroup(prj, "AppxManifest")
 		vc2010.deploymentcontentgroup(prj, "Image")
+		vc2010.deploymentcontentgroup(prj, "DeploymentContent", "None")
 	end
 
 	function vc2010.customtaskgroup(prj)
@@ -683,14 +684,20 @@
 		end
 	end
 
-	function vc2010.deploymentcontentgroup(prj, section)
+	function vc2010.deploymentcontentgroup(prj, section, filetype)
+		if filetype == nil then
+			filetype = section
+		end
+		
 		local files = vc2010.getfilegroup(prj, section)
 		if #files > 0  then
 			_p(1,'<ItemGroup>')
 			for _, file in ipairs(files) do
-				_p(2,'<%s Include=\"%s\">', section, path.translate(file.name, "\\"))
+				_p(2,'<%s Include=\"%s\">', filetype, path.translate(file.name, "\\"))
+				
 				_p(3,'<DeploymentContent>true</DeploymentContent>')
-				_p(2,'</%s>', section)
+				_p(3,'<Link>%s</Link>', path.translate(file.vpath, "\\"))
+				_p(2,'</%s>', filetype)
 			end
 			_p(1,'</ItemGroup>')
 		end

--- a/src/actions/vstudio/vs2010_vcxproj_filters.lua
+++ b/src/actions/vstudio/vs2010_vcxproj_filters.lua
@@ -82,8 +82,13 @@
 -- "ResourceCompile", or "None".
 --
 
-	function vc2010.filefiltergroup(prj, section)
+	function vc2010.filefiltergroup(prj, section, kind)
 		local files = vc2010.getfilegroup(prj, section) or {}
+		
+		if kind == nill then
+			kind = section
+		end
+		
 		if (section == "CustomBuild") then
 			for _, custombuildtask in ipairs(prj.custombuildtask or {}) do
 				for _, buildtask in ipairs(custombuildtask or {}) do
@@ -105,11 +110,11 @@
 				end				
 				
 				if filter ~= "." then
-					_p(2,'<%s Include=\"%s\">', section, path.translate(file.name, "\\"))
+					_p(2,'<%s Include=\"%s\">', kind, path.translate(file.name, "\\"))
 						_p(3,'<Filter>%s</Filter>', path.translate(filter, "\\"))
-					_p(2,'</%s>', section)
+					_p(2,'</%s>', kind)
 				else
-					_p(2,'<%s Include=\"%s\" />', section, path.translate(file.name, "\\"))
+					_p(2,'<%s Include=\"%s\" />', kind, path.translate(file.name, "\\"))
 				end
 			end
 			_p(1,'</ItemGroup>')
@@ -130,5 +135,8 @@
 			vc2010.filefiltergroup(prj, "ClCompile")
 			vc2010.filefiltergroup(prj, "ResourceCompile")
 			vc2010.filefiltergroup(prj, "CustomBuild")
+			vc2010.filefiltergroup(prj, "AppxManifest")
+			vc2010.filefiltergroup(prj, "Image")
+			vc2010.filefiltergroup(prj, "DeploymentContent", "None")
 		_p('</Project>')
 	end

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -139,6 +139,7 @@
 					ATL = 1,
 					DebugEnvsDontMerge = 1,
 					DebugEnvsInherit = 1,
+					DeploymentContent = 1,
 					EnableMinimalRebuild = 1,
 					EnableSSE = 1,
 					EnableSSE2 = 1,

--- a/src/base/path.lua
+++ b/src/base/path.lua
@@ -222,6 +222,11 @@
 		return table.contains(extensions, ext)
 	end
 
+	function path.isappxmanifest(fname)
+		local extensions = { ".appxmanifest" }
+		local ext = path.getextension(fname):lower()
+		return table.contains(extensions, ext)
+	end
 
 
 --


### PR DESCRIPTION
(needed for C++ Win Store apps).  Using file-level configuration, you can specify the "DeploymentContent" flag on a file or set of files.  These files will get marked with &lt;DeploymentContent&gt;true&lt;/DeploymentContent&gt; in the project file.

New pull request without scripts.c