### PR TITLE
Fix file-level multiprocessor compile for VS C++ projects

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -719,8 +719,8 @@
 			for _, file in ipairs(files) do
 				local translatedpath = path.translate(file.name, "\\")
 				_p(2, '<ClCompile Include=\"%s\">', translatedpath)
-				_p(3, '<ObjectFileName>$(IntDir)%s.obj</ObjectFileName>'
-					, premake.esc(path.translate(path.trimdots(path.removeext(file.name))))
+				_p(3, '<ObjectFileName>$(IntDir)%s\\</ObjectFileName>'
+					, premake.esc(path.translate(path.trimdots(path.getdirectory(file.name))))
 					)
 
 				--For Windows Store Builds, if the file is .c we have to exclude it from /ZW compilation


### PR DESCRIPTION
By specifying only the target directory, for the obj files, it allows MSBuild to put more files on a call to cl.exe.  This in turn allows for file-level multiprocessor cl.exe functionality to work.