### PR TITLE
Unicode flag sets up the character set in Visual Studio

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -117,6 +117,10 @@
 			_p(2,'<UseOfAtl>%s</UseOfAtl>', iif(cfg.flags.StaticATL, "Static", "Dynamic"))
 		end
 
+		if cfg.flags.Unicode then
+			_p(2,'<CharacterSet>Unicode</CharacterSet>')
+		end
+
 		if cfg.flags.Managed then
 			_p(2,'<CLRSupport>true</CLRSupport>')
 		end


### PR DESCRIPTION
Previous the 'Character Set' option in the general properties was not set, meaning it would default to MultiByte character set, even when the Unicode flag was set.