### PR TITLE
Support for recent XCode file types

### DIFF
--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -24,6 +24,7 @@
 			[".cxx"] = "Sources",
 			[".dylib"] = "Frameworks",
 			[".framework"] = "Frameworks",
+			[".tbd"] = "Frameworks",
 			[".m"] = "Sources",
 			[".mm"] = "Sources",
 			[".strings"] = "Resources",
@@ -32,6 +33,8 @@
 			[".icns"] = "Resources",
 			[".bmp"] = "Resources",
 			[".wav"] = "Resources",
+			[".xcassets"]  = "Resources",
+			[".xcdatamodeld"] = "Sources",
 		}
 		return categories[path.getextension(node.name)]
 	end
@@ -72,7 +75,9 @@
 			[".cpp"]       = "sourcecode.cpp.cpp",
 			[".css"]       = "text.css",
 			[".cxx"]       = "sourcecode.cpp.cpp",
+			[".entitlements"] = "text.xml",
 			[".framework"] = "wrapper.framework",
+			[".tbd"]       = "sourcecode.text-based-dylib-definition",
 			[".gif"]       = "image.gif",
 			[".h"]         = "sourcecode.c.h",
 			[".html"]      = "text.html",
@@ -87,6 +92,8 @@
 			[".icns"]      = "image.icns",
 			[".bmp"]       = "image.bmp",
 			[".wav"]       = "audio.wav",
+			[".xcassets"]  = "folder.assetcatalog",
+			[".xcdatamodeld"] = "wrapper.xcdatamodeld",
 		}
 		return types[path.getextension(node.path)] or "text"
 	end
@@ -107,7 +114,9 @@
 			[".cpp"]       = "sourcecode.cpp.cpp",
 			[".css"]       = "text.css",
 			[".cxx"]       = "sourcecode.cpp.cpp",
+			[".entitlements"] = "text.xml",
 			[".framework"] = "wrapper.framework",
+			[".tbd"]       = "wrapper.framework",
 			[".gif"]       = "image.gif",
 			[".h"]         = "sourcecode.cpp.h",
 			[".html"]      = "text.html",
@@ -122,6 +131,8 @@
 			[".icns"]      = "image.icns",
 			[".bmp"]       = "image.bmp",
 			[".wav"]       = "audio.wav",
+			[".xcassets"]  = "folder.assetcatalog",
+			[".xcdatamodeld"] = "wrapper.xcdatamodeld",
 		}
 		return types[path.getextension(node.path)] or "text"
 	end
@@ -192,7 +203,7 @@
 --
 
 	function xcode.isframework(fname)
-		return (path.getextension(fname) == ".framework")
+		return (path.getextension(fname) == ".framework" or path.getextension(fname) == ".tbd")
 	end
 
 
@@ -363,6 +374,8 @@
 								error('relative paths are not currently supported for frameworks')
 							end
 							pth = nodePath
+						elseif path.getextension(nodePath)=='.tbd' then
+							pth = "/usr/lib/" .. nodePath
 						else
 							pth = "/System/Library/Frameworks/" .. nodePath
 						end
@@ -826,6 +839,10 @@
 
 		_p(4,'SDKROOT = "%s";', xcode.toolset)
 		
+		if tr.entitlements then
+			_p(4,'CODE_SIGN_ENTITLEMENTS = "%s";', tr.entitlements.cfg.name)
+		end
+
 		local targetdir = path.getdirectory(cfg.buildtarget.bundlepath)
 		if targetdir ~= "." then
 			_p(4,'CONFIGURATION_BUILD_DIR = "$(SYMROOT)";');

--- a/src/actions/xcode/xcode_project.lua
+++ b/src/actions/xcode/xcode_project.lua
@@ -58,6 +58,15 @@
 			end
 		})
 		
+		-- fix .xcassets files, they should be treated as a file, not a folder
+		tree.traverse(tr, {
+			onbranch = function(node)
+				if path.getextension(node.name) == ".xcassets" then
+					node.children = {}
+				end
+			end
+		})
+				
 		-- the special folder "Frameworks" lists all linked frameworks
 		tr.frameworks = tree.new("Frameworks")
 		for cfg in premake.eachconfig(prj) do
@@ -118,6 +127,9 @@
 				if string.endswith(node.name, "Info.plist") then
 					tr.infoplist = node
 				end						
+				if string.endswith(node.name, ".entitlements") then
+					tr.entitlements = node
+				end
 			end
 		}, true)
 


### PR DESCRIPTION
1. entitlements file is detected and set (similar to how plist files are
handled)
2. tbd files work just like frameworks  (these are the recently
introduced text based stub libraries)
3. xcassets files are detected and added as resource folders
4. xcdatamodeld folders are compiled as source