### PR TITLE
Fix removeflags, now work with gmake

### DIFF
--- a/src/base/bake.lua
+++ b/src/base/bake.lua
@@ -175,10 +175,14 @@
 	end
 
 	local function removevalues(tbl, removes)
-		for i=#tbl,1,-1 do
+		for k, v in pairs(tbl) do
 			for _, pattern in ipairs(removes) do
-				if pattern == tbl[i] then
-					table.remove(tbl, i)
+				if pattern == tbl[k] then
+					if type(k) == "number" then 
+						table.remove(tbl, k) 
+					else 
+						tbl[k] = nil 
+					end
 					break
 				end
 			end

--- a/src/base/bake.lua
+++ b/src/base/bake.lua
@@ -167,7 +167,6 @@
 			for _, item in ipairs(src) do
 				if not tbl[item] then
 					table.insert(tbl, item)
-					tbl[item] = item
 				end
 			end
 		end

--- a/src/base/bake.lua
+++ b/src/base/bake.lua
@@ -167,6 +167,7 @@
 			for _, item in ipairs(src) do
 				if not tbl[item] then
 					table.insert(tbl, item)
+					tbl[item] = item
 				end
 			end
 		end


### PR DESCRIPTION
Sorry for the previous PR, I missed the unique check. The solution now is just erase both value and indexed value from the flags table. However, as I mentioned before, the following optimization seems unnecessary.

```
-- fixup the data`
for name, field in pairs(premake.fields) do
    -- re-key flag fields for faster lookups
    if field.isflags then
        local values = cfg[name]
        for _, flag in ipairs(values) do values[flag] = true end
    end
end
```