### PR TITLE
Flags enabling some old behavior

### DIFF
--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -6,6 +6,8 @@
 
 	premake.make.cpp = { }
 	premake.make.override = { }
+	premake.ignore_makefile_changes = false
+	
 	local cpp = premake.make.cpp
 	local make = premake.make
 
@@ -480,11 +482,18 @@
 		table.sort(prj.files)
 		for _, file in ipairs(prj.files or {}) do
 			if path.isSourceFile(file) then
-				_p('$(OBJDIR)/%s.o: %s $(GCH) %s'
-					, _MAKE.esc(path.trimdots(path.removeext(file)))
-					, _MAKE.esc(file)
-					, _MAKE.getmakefilename(prj, true)
-					)
+				if (premake.ignore_makefile_changes) then
+					_p('$(OBJDIR)/%s.o: %s $(GCH)'
+						, _MAKE.esc(path.trimdots(path.removeext(file)))
+						, _MAKE.esc(file)
+						)
+				else
+					_p('$(OBJDIR)/%s.o: %s $(GCH) %s'
+						, _MAKE.esc(path.trimdots(path.removeext(file)))
+						, _MAKE.esc(file)
+						, _MAKE.getmakefilename(prj, true)
+						)
+				end
 				if (path.isobjcfile(file) and prj.msgcompile_objc) then
 					_p('\t@echo ' .. prj.msgcompile_objc)
 				elseif prj.msgcompile then


### PR DESCRIPTION
Made new behavior default but added 
premake.check_regenerate and premake.ignore_makefile_changes flags to be able to be changed.

premake.check_regenerate when set on flase will not do mandatory checks.

premake.ignore_makefile_changes when set on true will not put all  *.o files to be dependent of makefile 


