### PR TITLE
support for 'Cocoa Bundle' 

### DIFF
--- a/docs/scripting-reference.md
+++ b/docs/scripting-reference.md
@@ -758,8 +758,9 @@ _kind_ - project kind identifier. One of:
 
 * _ConsoleApp_ - console executable
 * _WindowedApp_ - application that runs in a desktop window. Does not apply on Linux.
-* _SharedLib_ - shared library or DLL
 * _StaticLib_ - static library
+* _SharedLib_ - shared library or DLL
+* _Bundle_ - Xcode: Cocoa Bundle, everywhere else: alias to _SharedLib_
 
 #### Examples
 ```lua

--- a/src/actions/cmake/_cmake.lua
+++ b/src/actions/cmake/_cmake.lua
@@ -10,7 +10,7 @@ newaction {
 	trigger         = "cmake",
 	shortname       = "CMake",
 	description     = "Generate CMake project files",
-	valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+	valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle" },
 	valid_languages = { "C", "C++" },
 	valid_tools     = {
 	cc   = { "gcc" },

--- a/src/actions/example/_example.lua
+++ b/src/actions/example/_example.lua
@@ -29,7 +29,7 @@
 		-- os = "macosx",
 
 		-- Which kinds of targets this action supports; remove those you don't.
-		valid_kinds = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_kinds = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle" },
 
 		-- Which programming languages this actions supports; remove those you don't.
 		valid_languages = { "C", "C++", "C#" },

--- a/src/actions/example/_example.lua
+++ b/src/actions/example/_example.lua
@@ -29,7 +29,7 @@
 		-- os = "macosx",
 
 		-- Which kinds of targets this action supports; remove those you don't.
-		valid_kinds = { "ConsoleApp", "WindowedApp", "SharedLib", "StaticLib" },
+		valid_kinds = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
 
 		-- Which programming languages this actions supports; remove those you don't.
 		valid_languages = { "C", "C++", "C#" },

--- a/src/actions/fastbuild/_fastbuild.lua
+++ b/src/actions/fastbuild/_fastbuild.lua
@@ -10,8 +10,9 @@
 		valid_kinds = {
 			"ConsoleApp",
 			"WindowedApp",
+			"StaticLib",
 			"SharedLib",
-			"StaticLib"
+			"Bundle",
 		},
 
 		valid_languages = {

--- a/src/actions/make/_make.lua
+++ b/src/actions/make/_make.lua
@@ -132,7 +132,7 @@
 		shortname       = "GNU Make",
 		description     = "Generate GNU makefiles for POSIX, MinGW, and Cygwin",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle" },
 
 		valid_languages = { "C", "C++", "C#", "Vala", "Swift" },
 

--- a/src/actions/ninja/_ninja.lua
+++ b/src/actions/ninja/_ninja.lua
@@ -16,7 +16,7 @@ newaction
 	module      = "ninja",
 
 	-- The capabilities of this action
-	valid_kinds     = {"ConsoleApp", "WindowedApp", "StaticLib", "SharedLib"},
+	valid_kinds     = {"ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle"},
 	valid_languages = {"C", "C++", "Swift"},
 	valid_tools     = {
 		cc    = { "gcc" },

--- a/src/actions/ninja/_ninja.lua
+++ b/src/actions/ninja/_ninja.lua
@@ -16,7 +16,7 @@ newaction
 	module      = "ninja",
 
 	-- The capabilities of this action
-	valid_kinds     = {"ConsoleApp", "WindowedApp", "SharedLib", "StaticLib"},
+	valid_kinds     = {"ConsoleApp", "WindowedApp", "StaticLib", "SharedLib"},
 	valid_languages = {"C", "C++", "Swift"},
 	valid_tools     = {
 		cc    = { "gcc" },

--- a/src/actions/qbs/_qbs.lua
+++ b/src/actions/qbs/_qbs.lua
@@ -16,7 +16,7 @@ newaction
 	module      = "qbs",
 
 	-- The capabilities of this action
-	valid_kinds     = {"ConsoleApp", "WindowedApp", "StaticLib", "SharedLib"},
+	valid_kinds     = {"ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle"},
 	valid_languages = {"C", "C++"},
 	valid_tools     = {
 		cc = { "gcc" },

--- a/src/actions/qbs/_qbs.lua
+++ b/src/actions/qbs/_qbs.lua
@@ -16,7 +16,7 @@ newaction
 	module      = "qbs",
 
 	-- The capabilities of this action
-	valid_kinds     = {"ConsoleApp", "WindowedApp", "SharedLib", "StaticLib"},
+	valid_kinds     = {"ConsoleApp", "WindowedApp", "StaticLib", "SharedLib"},
 	valid_languages = {"C", "C++"},
 	valid_tools     = {
 		cc = { "gcc" },

--- a/src/actions/vstudio/_vstudio.lua
+++ b/src/actions/vstudio/_vstudio.lua
@@ -274,7 +274,7 @@
 		description     = "Generate Microsoft Visual Studio 2008 project files",
 		os              = "windows",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle" },
 
 		valid_languages = { "C", "C++", "C#" },
 
@@ -321,7 +321,7 @@
 		description     = "Generate Microsoft Visual Studio 2010 project files",
 		os              = "windows",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle" },
 
 		valid_languages = { "C", "C++", "C#"},
 

--- a/src/actions/vstudio/vs15.lua
+++ b/src/actions/vstudio/vs15.lua
@@ -17,7 +17,7 @@
 		description     = "Generate Microsoft Visual Studio 15 project files",
 		os              = "windows",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle" },
 
 		valid_languages = { "C", "C++", "C#" },
 

--- a/src/actions/vstudio/vs2012.lua
+++ b/src/actions/vstudio/vs2012.lua
@@ -20,7 +20,7 @@
 		description     = "Generate Microsoft Visual Studio 2012 project files",
 		os              = "windows",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle" },
 
 		valid_languages = { "C", "C++", "C#"},
 

--- a/src/actions/vstudio/vs2013.lua
+++ b/src/actions/vstudio/vs2013.lua
@@ -20,7 +20,7 @@
 		description     = "Generate Microsoft Visual Studio 2013 project files",
 		os              = "windows",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle" },
 
 		valid_languages = { "C", "C++", "C#"},
 

--- a/src/actions/vstudio/vs2015.lua
+++ b/src/actions/vstudio/vs2015.lua
@@ -19,7 +19,7 @@
 		description     = "Generate Microsoft Visual Studio 2015 project files",
 		os              = "windows",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle" },
 
 		valid_languages = { "C", "C++", "C#" },
 

--- a/src/actions/xcode/_xcode.lua
+++ b/src/actions/xcode/_xcode.lua
@@ -39,7 +39,7 @@
 		description     = "Generate Apple Xcode 3 project files (experimental)",
 		os              = "macosx",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "SharedLib", "StaticLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
 
 		valid_languages = { "C", "C++" },
 
@@ -81,7 +81,7 @@
 		description     = "Generate Apple Xcode 4 project files (experimental)",
 		os              = "macosx",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "SharedLib", "StaticLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
 
 		valid_languages = { "C", "C++" },
 

--- a/src/actions/xcode/_xcode.lua
+++ b/src/actions/xcode/_xcode.lua
@@ -39,7 +39,7 @@
 		description     = "Generate Apple Xcode 3 project files (experimental)",
 		os              = "macosx",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle" },
 
 		valid_languages = { "C", "C++" },
 
@@ -81,7 +81,7 @@
 		description     = "Generate Apple Xcode 4 project files (experimental)",
 		os              = "macosx",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Bundle" },
 
 		valid_languages = { "C", "C++" },
 

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -23,6 +23,7 @@
 			[".cpp"] = "Sources",
 			[".cxx"] = "Sources",
 			[".dylib"] = "Frameworks",
+			[".bundle"] = "Frameworks",
 			[".framework"] = "Frameworks",
 			[".tbd"] = "Frameworks",
 			[".m"] = "Sources",
@@ -78,6 +79,7 @@
 			[".css"]       = "text.css",
 			[".cxx"]       = "sourcecode.cpp.cpp",
 			[".entitlements"] = "text.xml",
+			[".bundle"]    = "wrapper.cfbundle",
 			[".framework"] = "wrapper.framework",
 			[".tbd"]       = "sourcecode.text-based-dylib-definition",
 			[".gif"]       = "image.gif",
@@ -119,6 +121,7 @@
 			[".css"]       = "text.css",
 			[".cxx"]       = "sourcecode.cpp.cpp",
 			[".entitlements"] = "text.xml",
+			[".bundle"]    = "wrapper.cfbundle",
 			[".framework"] = "wrapper.framework",
 			[".tbd"]       = "wrapper.framework",
 			[".gif"]       = "image.gif",
@@ -156,6 +159,7 @@
 			WindowedApp = "com.apple.product-type.application",
 			StaticLib   = "com.apple.product-type.library.static",
 			SharedLib   = "com.apple.product-type.library.dynamic",
+			Bundle      = "com.apple.product-type.bundle",
 		}
 		return types[node.cfg.kind]
 	end
@@ -176,6 +180,7 @@
 			WindowedApp = "wrapper.application",
 			StaticLib   = "archive.ar",
 			SharedLib   = "\"compiled.mach-o.dylib\"",
+			Bundle      = "wrapper.cfbundle",
 		}
 		return types[node.cfg.kind]
 	end
@@ -804,6 +809,7 @@
 			WindowedApp = '"$(HOME)/Applications"',
 			SharedLib = '/usr/local/lib',
 			StaticLib = '/usr/local/lib',
+			Bundle    = '"$(LOCAL_LIBRARY_DIR)/Bundles"',
 		}
 		_p(4,'INSTALL_PATH = %s;', installpaths[cfg.kind])
 
@@ -820,7 +826,16 @@
 			_p(4,'INFOPLIST_FILE = "%s";', infoplist_file)
 		end
 
+		if cfg.kind == "Bundle" then
+			_p(4, 'PRODUCT_BUNDLE_IDENTIFIER = "genie.%s";', cfg.buildtarget.basename:gsub("%s+", '.')) --replace spaces with .
+		end
+
 		_p(4,'PRODUCT_NAME = "%s";', cfg.buildtarget.basename)
+
+		if cfg.kind == "Bundle" then
+			_p(4, 'WRAPPER_EXTENSION = bundle;')
+		end
+
 		_p(3,'};')
 		_p(3,'name = "%s";', cfgname)
 		_p(2,'};')

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -337,7 +337,8 @@
 				"ConsoleApp",
 				"WindowedApp",
 				"StaticLib",
-				"SharedLib"
+				"SharedLib",
+				"Bundle",
 			}
 		},
 

--- a/src/base/bake.lua
+++ b/src/base/bake.lua
@@ -731,6 +731,10 @@
 		end
 
 		-- adjust the kind as required by the target system
+		if cfg.kind == "Bundle" and not _ACTION:match("xcode[0-9]") then
+			cfg.kind = "SharedLib"
+		end
+
 		if cfg.kind == "SharedLib" and platform.nosharedlibs then
 			cfg.kind = "StaticLib"
 		end

--- a/tests/actions/test_clean.lua
+++ b/tests/actions/test_clean.lua
@@ -147,6 +147,18 @@
 	end
 
 
+	function T.clean.CppBundleFiles()
+		prj = project "MyProject"
+		language "C++"
+		kind "Bundle"
+		prepare()
+		test.contains(removed, "MyProject.dll")
+		test.contains(removed, "libMyProject.so")
+		test.contains(removed, "MyProject.lib")
+		test.contains(removed, "MyProject.bundle")
+	end
+
+
 	function T.clean.CppStaticLibFiles()
 		prj = project "MyProject"
 		language "C++"

--- a/tests/actions/xcode/test_xcode_dependencies.lua
+++ b/tests/actions/xcode/test_xcode_dependencies.lua
@@ -60,6 +60,17 @@
 		]]
 	end
 
+	function suite.PBXBuildFile_ListsDependencyTargets_OnBundle()
+		kind "Bundle"
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		[MyProject2-d.bundle:build] /* MyProject2-d.bundle in Frameworks */ = {isa = PBXBuildFile; fileRef = [MyProject2-d.bundle] /* MyProject2-d.bundle */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
 
 ---------------------------------------------------------------------------
 -- PBXContainerItemProxy tests
@@ -150,6 +161,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				[libMyProject2-d.dylib:build] /* libMyProject2-d.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+		]]
+	end
+
+	function suite.PBXFrameworksBuildPhase_ListsDependencies_OnBundle()
+		kind "Bundle"
+		prepare()
+		xcode.PBXFrameworksBuildPhase(tr)
+		test.capture [[
+/* Begin PBXFrameworksBuildPhase section */
+		[MyProject:fxs] /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				[MyProject2-d.bundle:build] /* MyProject2-d.bundle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/actions/xcode/test_xcode_project.lua
+++ b/tests/actions/xcode/test_xcode_project.lua
@@ -147,6 +147,18 @@
 	end
 
 
+	function suite.PBXFileReference_ListsBundleTarget()
+		kind "Bundle"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[MyProject.bundle:product] /* MyProject.bundle */ = {isa = PBXFileReference; explicitFileType = "wrapper.cfbundle"; includeInIndex = 0; name = "MyProject.bundle"; path = "MyProject.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+
 	function suite.PBXFileReference_ListsSourceFiles()
 		files { "source.c" }
 		prepare()
@@ -611,6 +623,34 @@
 	end
 
 
+	function suite.PBXNativeTarget_OnBundle()
+		kind "Bundle"
+		prepare()
+		xcode.PBXNativeTarget(tr) --TODO adapt
+		test.capture [[
+/* Begin PBXNativeTarget section */
+		MyProject.bundle:target] /* MyProject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = [MyProject.bundle:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildPhases = (
+				[MyProject.bundle:rez] /* Resources */,
+				[MyProject.bundle:src] /* Sources */,
+				[MyProject.bundle:fxs] /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "MyProject";
+			productName = "MyProject";
+			productReference = [MyProject.bundle:product] /* MyProject.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+/* End PBXNativeTarget section */
+		]]
+	end
+
+
 	function suite.PBXNativeTarget_OnBuildCommands()
 		prebuildcommands { "prebuildcmd" }
 		prelinkcommands { "prelinkcmd" }
@@ -931,6 +971,29 @@
 				GCC_MODEL_TUNING = G5;
 				INSTALL_PATH = /usr/local/lib;
 				PRODUCT_NAME = "MyProject";
+			};
+			name = "Debug";
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnBundle()
+		kind "Bundle"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[libMyProject.dylib:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_PREFIX = lib;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_MODEL_TUNING = G5;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				PRODUCT_NAME = "MyProject";
+				PRODUCT_BUNDLE_IDENTIFIER = genie.MyProject;
 			};
 			name = "Debug";
 		};

--- a/tests/test_targets.lua
+++ b/tests/test_targets.lua
@@ -156,6 +156,58 @@
 	end
 
 
+--
+-- Bundle tests
+--
+
+	function T.targets.Bundle_Build_WindowsNames()
+		cfg.kind = "Bundle"
+		result = premake.gettarget(cfg, "build", "posix", "windows", "macosx")
+		test.isequal([[../bin/MyProject.dll]], result.fullpath)
+	end
+
+	function T.targets.Bundle_Link_WindowsNames()
+		cfg.kind = "Bundle"
+		result = premake.gettarget(cfg, "link", "posix", "windows", "macosx")
+		test.isequal([[../bin/MyProject.lib]], result.fullpath)
+	end
+
+	function T.targets.Bundle_Build_PosixNames_OnWindows()
+		cfg.kind = "Bundle"
+		result = premake.gettarget(cfg, "build", "posix", "posix", "windows")
+		test.isequal([[../bin/MyProject.dll]], result.fullpath)
+	end
+
+	function T.targets.Bundle_Link_PosixNames_OnWindows()
+		cfg.kind = "Bundle"
+		result = premake.gettarget(cfg, "link", "posix", "posix", "windows")
+		test.isequal([[../bin/libMyProject.a]], result.fullpath)
+	end
+
+	function T.targets.Bundle_Build_PosixNames_OnLinux()
+		cfg.kind = "Bundle"
+		result = premake.gettarget(cfg, "build", "posix", "posix", "linux")
+		test.isequal([[../bin/libMyProject.so]], result.fullpath)
+	end
+
+	function T.targets.Bundle_Link_PosixNames_OnLinux()
+		cfg.kind = "Bundle"
+		result = premake.gettarget(cfg, "link", "posix", "posix", "linux")
+		test.isequal([[../bin/libMyProject.so]], result.fullpath)
+	end
+
+	function T.targets.Bundle_Build_PosixNames_OnMacOSX()
+		cfg.kind = "Bundle"
+		result = premake.gettarget(cfg, "build", "posix", "posix", "macosx")
+		test.isequal([[../bin/MyProject.bundle]], result.fullpath)
+	end
+
+	function T.targets.Bundle_Link_PosixNames_OnMacOSX()
+		cfg.kind = "Bundle"
+		result = premake.gettarget(cfg, "link", "posix", "posix", "macosx")
+		test.isequal([[../bin/MyProject.bundle]], result.fullpath)
+	end
+
 
 --
 -- StaticLib tests


### PR DESCRIPTION
Fix for #251 
These changes have the following effect:
- add kind 'Bundle' to build Cocoa Bundles from Xcode
- alias 'Bundle' to 'SharedLib' for all non-Xcode actions
