### PR TITLE
use _PREMAKE_COMMAND global rather than genie for exec() in release.lua

### DIFF
--- a/scripts/release.lua
+++ b/scripts/release.lua
@@ -29,7 +29,7 @@ function dorelease()
 
 	print("Updating embedded scripts...")
 
-	local z = exec("genie embed")
+	local z = exec(_PREMAKE_COMMAND .. " embed")
 	if z ~= true then
 		error("** Failed to update the embedded scripts", 0)
 	end
@@ -37,9 +37,9 @@ function dorelease()
 
 	print("Generating project files...")
 
-	exec("genie /to=../build/gmake.windows /os=windows gmake")
-	exec("genie /to=../build/gmake.linux /os=linux gmake")
-	exec("genie /to=../build/gmake.darwin /os=macosx /platform=universal32 gmake")
+	exec(_PREMAKE_COMMAND .. " /to=../build/gmake.windows /os=windows gmake")
+	exec(_PREMAKE_COMMAND .. " /to=../build/gmake.linux /os=linux gmake")
+	exec(_PREMAKE_COMMAND .. " /to=../build/gmake.darwin /os=macosx /platform=universal32 gmake")
 
 	print("")
 	print( "Finished.")


### PR DESCRIPTION
attempts to call `genie release` were failing because `genie` wasn't yeti in my `$PATH`, this uses the `_PREMAKE_COMMAND` global for the recursive calls to `genie`.

Not sure if you'd prefer to alias or rename `_PREMAKE_COMMAND` to `_GENIE_COMMAND`?