### PR TITLE
correct relative paths for linking static libs with ninja

### DIFF
--- a/src/base/project.lua
+++ b/src/base/project.lua
@@ -374,7 +374,7 @@
 				end
 
 				if item:find("/", nil, true) then
-					item = path.getrelative(cfg.project.location, item)
+					item = path.getrelative(cfg.location, item)
 				end
 
 			end


### PR DESCRIPTION
Fixes a relative path issue I was seeing using ninja vs gmake.

`~/code/otherlib/otherlib.a`
`~/code/myproject/build/gmake`

correctly resolved to `../../../otherlib/otherlib.a`, but ninja builds use an extra subdirectory (eg `release64`) so the resolution should be `../../../../otherlib/otherlib.a`

Untested with the other targets.