### PR TITLE
Made gmake understand "Bundle" project kind. 

### DIFF
--- a/src/base/bake.lua
+++ b/src/base/bake.lua
@@ -767,7 +767,7 @@
 		end
 
 		-- adjust the kind as required by the target system
-		if cfg.kind == "Bundle" and not _ACTION:match("xcode[0-9]") then
+		if cfg.kind == "Bundle" and _ACTION ~= "gmake" and not _ACTION:match("xcode[0-9]") then
 			cfg.kind = "SharedLib"
 		end
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -169,6 +169,10 @@
 			end
 		end
 
+		if cfg.kind == "Bundle" then
+			table.insert(result, "-bundle")
+		end
+
 		if cfg.kind == "SharedLib" then
 			if cfg.system == "macosx" then
 				table.insert(result, "-dynamiclib")


### PR DESCRIPTION
While creating an actual bundle directory the way XCode might be out of scope for other generators, linking with the `--bundle` flag instead of `--dynlib` is essential if the output binary is supposed to go into a bundle (e.g. in a later packaging step).