### PR TITLE
Made WindowedApp project kind understand the SkipBundling option

### DIFF
--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -66,7 +66,7 @@
 		_p('.PHONY: clean prebuild prelink')
 		_p('')
 
-		if os.is("MacOSX") and prj.kind == "WindowedApp" then
+		if os.is("MacOSX") and prj.kind == "WindowedApp" and not prj.options.SkipBundling then
 			_p('all: $(OBJDIRS) $(TARGETDIR) prebuild prelink $(TARGET) $(dir $(TARGETDIR))PkgInfo $(dir $(TARGETDIR))Info.plist')
 		else
 			_p('all: $(OBJDIRS) $(TARGETDIR) prebuild prelink $(TARGET)')
@@ -136,7 +136,7 @@
 		_p('')
 
 		-- Mac OS X specific targets
-		if os.is("MacOSX") and prj.kind == "WindowedApp" then
+		if os.is("MacOSX") and prj.kind == "WindowedApp" and not prj.options.SkipBundling then
 			_p('$(dir $(TARGETDIR))PkgInfo:')
 			_p('$(dir $(TARGETDIR))Info.plist:')
 			_p('')

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -159,10 +159,10 @@
 	function xcode.getproducttype(node)
 		local types = {
 			ConsoleApp  = "com.apple.product-type.tool",
-			WindowedApp = "com.apple.product-type.application",
+			WindowedApp = node.cfg.options.SkipBundling and "com.apple.product-type.tool" or "com.apple.product-type.application",
 			StaticLib   = "com.apple.product-type.library.static",
 			SharedLib   = "com.apple.product-type.library.dynamic",
-			Bundle      = node.cfg.options.SkipBundling and "com.apple.product-type.tool" or "com.apple.product-type.bundle", -- Ternary operator-ish
+			Bundle      = node.cfg.options.SkipBundling and "com.apple.product-type.tool" or "com.apple.product-type.bundle",
 		}
 		return types[node.cfg.kind]
 	end
@@ -180,10 +180,10 @@
 	function xcode.gettargettype(node)
 		local types = {
 			ConsoleApp  = "\"compiled.mach-o.executable\"",
-			WindowedApp = "wrapper.application",
+			WindowedApp = node.cfg.options.SkipBundling and "\"compiled.mach-o.executable\"" or "wrapper.application",
 			StaticLib   = "archive.ar",
 			SharedLib   = "\"compiled.mach-o.dylib\"",
-			Bundle      = node.cfg.options.SkipBundling and "\"compiled.mach-o.bundle\"" or "wrapper.cfbundle", -- Ternary operator-ish
+			Bundle      = node.cfg.options.SkipBundling and "\"compiled.mach-o.bundle\"" or "wrapper.cfbundle",
 		}
 		return types[node.cfg.kind]
 	end

--- a/src/base/project.lua
+++ b/src/base/project.lua
@@ -506,7 +506,7 @@
 				ext = ".lib"
 			end
 		elseif namestyle == "posix" then
-			if kind == "WindowedApp" and system == "macosx" then
+			if kind == "WindowedApp" and system == "macosx" and not cfg.options.SkipBundling then
 				bundlename = name .. ".app"
 				bundlepath = path.join(dir, bundlename)
 				dir = path.join(bundlepath, "Contents/MacOS")


### PR DESCRIPTION
This turned out a slight bit odd since it pretty much makes WindowedApp+SkipBundling almost identical to ConsoleApp on OS X. It does make sense though when you want to do the bundling manually on OS X but still semantically have it as a WindowedApp on all platforms.