### PR TITLE
Changed obj file output directory scheme in vcproj files

### DIFF
--- a/src/actions/vstudio/vstudio_vcxproj.lua
+++ b/src/actions/vstudio/vstudio_vcxproj.lua
@@ -1071,7 +1071,7 @@
 			for _, file in ipairs(files) do
 				-- Having unique ObjectFileName for each file subverts MSBuilds ability to parallelize compilation with the /MP flag.
 				-- Instead we detect duplicates and partition them in subfolders only if needed.
-				local filename = string.lower(path.getname(file.name))
+				local filename = string.lower(path.getbasename(file.name))
 				local disambiguation = existingBasenames[filename] or 0;
 				existingBasenames[filename] = disambiguation + 1
 

--- a/src/actions/vstudio/vstudio_vcxproj.lua
+++ b/src/actions/vstudio/vstudio_vcxproj.lua
@@ -1071,13 +1071,9 @@
 			for _, file in ipairs(files) do
 				-- Having unique ObjectFileName for each file subverts MSBuilds ability to parallelize compilation with the /MP flag.
 				-- Instead we detect duplicates and partition them in subfolders only if needed.
-				local basename = path.getbasename(file.name)
-				local disambiguation = existingBasenames[basename] or 0;
-				if disambiguation > 0 then
-					existingBasenames[basename] = disambiguation + 1
-				else
-					existingBasenames[basename] = 1
-				end
+				local filename = string.lower(path.getname(file.name))
+				local disambiguation = existingBasenames[filename] or 0;
+				existingBasenames[filename] = disambiguation + 1
 
 				local translatedpath = path.translate(file.name, "\\")
 				_p(2, '<ClCompile Include=\"%s\">', translatedpath)


### PR DESCRIPTION
Parallel builds using /MP in VS/MSBuild requires all files to build in parallel to have the exact same command line options. (Parallel builds are implemented through calling cl.exe with multiple input files and the /MP flag.) The way GENie sets individual obj output folders to each input file means only files within the same folder can be built in parallel.

This patch changes the obj directory scheme to instead put all obj files in the same directory, with the exception for files with duplicate file names (which would result in obj file collisions). The second item with the same name is put in a /1/ subfolder, third in a /2/ subfolder, etc. This should maximize the parallelization opportunities without resulting in collisions.

The actual collision search is done using a pretty naive Lua table lookup. I'm not totally sure about the Lua table lookup speed, but since it's the central datatype I expect it to be fast and the search should in total be something like N*log(N).