### PR TITLE
Added xcodecopyresources

### DIFF
--- a/src/actions/xcode/xcode10.lua
+++ b/src/actions/xcode/xcode10.lua
@@ -49,6 +49,7 @@
 		xcode.PBXReferenceProxy(tr)
 		xcode.PBXResourcesBuildPhase(tr)
 		xcode.PBXShellScriptBuildPhase(tr)
+		xcode.PBXCopyFilesBuildPhase(tr)
 		xcode.PBXSourcesBuildPhase(tr,prj)
 		xcode.PBXVariantGroup(tr)
 		xcode.PBXTargetDependency(tr)

--- a/src/actions/xcode/xcode8.lua
+++ b/src/actions/xcode/xcode8.lua
@@ -290,6 +290,7 @@
 		xcode.PBXReferenceProxy(tr)
 		xcode.PBXResourcesBuildPhase(tr)
 		xcode.PBXShellScriptBuildPhase(tr)
+		xcode.PBXCopyFilesBuildPhase(tr)
 		xcode.PBXSourcesBuildPhase(tr,prj)
 		xcode.PBXVariantGroup(tr)
 		xcode.PBXTargetDependency(tr)

--- a/src/actions/xcode/xcode9.lua
+++ b/src/actions/xcode/xcode9.lua
@@ -40,6 +40,7 @@
 		xcode.PBXReferenceProxy(tr)
 		xcode.PBXResourcesBuildPhase(tr)
 		xcode.PBXShellScriptBuildPhase(tr)
+		xcode.PBXCopyFilesBuildPhase(tr)
 		xcode.PBXSourcesBuildPhase(tr,prj)
 		xcode.PBXVariantGroup(tr)
 		xcode.PBXTargetDependency(tr)

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -685,9 +685,27 @@ end
 				end
 			end
 
+			local function docopyresources(which, action)
+				if hasBuildCommands(which) then
+					local targets = tr.project[which]
+					if #targets > 0 then
+						local i = 0
+						for _, t in ipairs(targets) do
+							for __, tt in ipairs(t) do
+								local label = xcode.getcopyphaselabel('Resources', i, tt[1])
+								local id = xcode.uuid(label)
+								action(id, label)
+								i = i + 1
+							end
+						end
+					end
+				end
+			end
+
 			local function _p_label(id, label)
 				_p(4, '%s /* %s */,', id, label)
 			end
+
 
 			_p(2,'%s /* %s */ = {', node.targetid, name)
 			_p(3,'isa = PBXNativeTarget;')
@@ -700,6 +718,7 @@ end
 			_p(4,'%s /* Frameworks */,', node.fxstageid)
 			dobuildblock('9607AE3710C85E8F00CD1376', 'Postbuild', 'postbuildcommands', _p_label)
 			doscriptphases("xcodescriptphases", _p_label)
+			docopyresources("xcodecopyresources", _p_label)
 
 			_p(3,');')
 			_p(3,'buildRules = (')

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -303,6 +303,29 @@
 		return string.format("\"Script Phase %s [%s] (%s)\"", count, cmd:match("(%w+)(.+)"), iif(cfg, xcode.getconfigname(cfg), "all"))
 	end
 
+
+--
+-- Creates a label for a given copy phase
+--  based on target
+-- such as the result looks like this:
+-- 'Copy <type> <number> [target]', e.g. 'Copy Files 1 [assets]'
+--
+-- This function is used for generating `PBXCopyFilesPhase` from `xcodecopyresources`.
+-- (Thus required in more than 1 place).
+--
+-- @param type
+--    The copy type ('Resources' for now)
+-- @param count
+--    counter to avoid having duplicate label names
+-- @param target
+--    The target subfolder
+--
+
+	function xcode.getcopyphaselabel(type, count, target)
+		return string.format("\"Copy %s %s [%s]\"", type, count, target)
+	end
+
+
 --
 -- Create a product tree node and all projects in a solution; assigning IDs
 -- that are needed for inter-project dependencies.

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -751,6 +751,12 @@
 			scope = "config",
 		},
 
+		xcodecopyresources =
+		{
+			kind  = "table",
+			scope = "project",
+		},
+
 		wholearchive =
 		{
 			kind  = "list",


### PR DESCRIPTION
@bkaradzic @rhoot 
Hi again,

here's the next PR I'd like you to check and eventually merge: this one adds support `xcodecopyresources` which yield PBXCopyFilesPhases.
In order to copy files, the Xcode project also needs to have separate UUID entries for each file or folder to copied. This is handled here as well.

Best regards.

