### PR TITLE
Added `xcodecopyframeworks`

### DIFF
--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -440,9 +440,12 @@ end
 				end
 
 				-- adds duplicate PBXBuildFile file entry as 'CopyFiles' for files marked to be copied
+				-- for frameworks: add signOnCopy flag
 				if table.icontains(copyfiles, node.name) then
-					_p(2,'%s /* %s in %s */ = {isa = PBXBuildFile; fileRef = %s /* %s */; };',
-						xcode.uuid(node.name .. 'in CopyFiles'), node.name, 'CopyFiles', node.id, node.name)
+					_p(2,'%s /* %s in %s */ = {isa = PBXBuildFile; fileRef = %s /* %s */; %s };',
+						xcode.uuid(node.name .. 'in CopyFiles'), node.name, 'CopyFiles', node.id, node.name,
+						iif(xcode.isframework(node.name), "settings = {ATTRIBUTES = (CodeSignOnCopy, ); };", "")
+					)
 				end
 			end
 		})

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -429,7 +429,19 @@ end
 			return table.translate(copyfiles, path.getname)
 		end
 
-		local copyfiles = gatherCopyFiles('xcodecopyresources')
+		local function gatherCopyFrameworks(which)
+			local copyfiles = {}
+			local targets = tr.project[which]
+			if #targets > 0 then
+				table.insertflat(copyfiles, targets)
+			end
+			return table.translate(copyfiles, path.getname)
+		end
+
+		local copyfiles = table.flatten({
+			gatherCopyFiles('xcodecopyresources'),
+			gatherCopyFrameworks('xcodecopyframeworks')
+		})
 
 		_p('/* Begin PBXBuildFile section */')
 		tree.traverse(tr, {

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -721,6 +721,17 @@ end
 				end
 			end
 
+			local function docopyframeworks(which, action)
+				if hasBuildCommands(which) then
+					local targets = tr.project[which]
+					if #targets > 0 then
+						local label = "Copy Frameworks"
+						local id = xcode.uuid(label)
+						action(id, label)
+					end
+				end
+			end
+
 			local function _p_label(id, label)
 				_p(4, '%s /* %s */,', id, label)
 			end
@@ -738,6 +749,7 @@ end
 			dobuildblock('9607AE3710C85E8F00CD1376', 'Postbuild', 'postbuildcommands', _p_label)
 			doscriptphases("xcodescriptphases", _p_label)
 			docopyresources("xcodecopyresources", _p_label)
+			docopyframeworks("xcodecopyframeworks", _p_label)
 
 			_p(3,');')
 			_p(3,'buildRules = (')

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -749,7 +749,9 @@ end
 			dobuildblock('9607AE3710C85E8F00CD1376', 'Postbuild', 'postbuildcommands', _p_label)
 			doscriptphases("xcodescriptphases", _p_label)
 			docopyresources("xcodecopyresources", _p_label)
-			docopyframeworks("xcodecopyframeworks", _p_label)
+			if tr.project.kind == "WindowedApp" then
+				docopyframeworks("xcodecopyframeworks", _p_label)
+			end
 
 			_p(3,');')
 			_p(3,'buildRules = (')
@@ -1045,7 +1047,9 @@ end
 		end
 
 		docopyresources("xcodecopyresources")
-		docopyframeworks("xcodecopyframeworks")
+		if tr.project.kind == "WindowedApp" then
+			docopyframeworks("xcodecopyframeworks")
+		end
 
 		if wrapperWritten then
 			_p('/* End PBXCopyFilesBuildPhase section */')

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -527,7 +527,8 @@ end
 						end
 						if string.find(nodePath,'/')  then
 							if string.find(nodePath,'^%.')then
-								error('relative paths are not currently supported for frameworks')
+								--error('relative paths are not currently supported for frameworks')
+								nodePath = path.getabsolute(path.join(tr.project.location, nodePath))
 							end
 							pth = nodePath
 						elseif path.getextension(nodePath)=='.tbd' then

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -1034,7 +1034,18 @@ end
 			end
 		end
 
+		local function docopyframeworks(which)
+			local targets = tr.project[which]
+			if #targets > 0 then
+				local label = "Copy Frameworks"
+				local id = xcode.uuid(label)
+				local files = table.translate(table.flatten(targets), path.getname)
+				doblock(id, label, 10, "", files)
+			end
+		end
+
 		docopyresources("xcodecopyresources")
+		docopyframeworks("xcodecopyframeworks")
 
 		if wrapperWritten then
 			_p('/* End PBXCopyFilesBuildPhase section */')

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -757,6 +757,12 @@
 			scope = "project",
 		},
 
+		xcodecopyframeworks =
+		{
+			kind  = "filelist",
+			scope = "project",
+		},
+
 		wholearchive =
 		{
 			kind  = "list",


### PR DESCRIPTION
Hello again, @bkaradzic @rhoot 

This PR is the continuation of #394: it adds `xcodecopyframeworks` which adds frameworks as `CopyFiles` target with `signOnCopy` set correctly.
It also allows relative-path for frameworks.

usage:
```
links { "local/path/bgfx.framework" }
xcodecopyframeworks { "local/path/bgfx.framework" }
```

Best regards.