### PR TITLE
Makefile groupedlinks

### DIFF
--- a/docs/scripting-reference.md
+++ b/docs/scripting-reference.md
@@ -648,6 +648,7 @@ _flags_ - List of flag names from list below. Names are case-insensitive and ign
 * _NoFramePointer_ - Disable the generation of stack frame pointers.
 * _NoIncrementalLink_ - Disable support for Visual Studio's incremental linking feature.
 * _NoImportLib_ - Prevent the generation of an import library for a Windows DLL.
+* _NoLibGroups_ - Prevent the linker from iterating over library groups to resolve symbols (make and ninja only).
 * _NoManifest_ - Prevent the generation of a manifest for Windows executables and shared libraries.
 * _NoMultiProcessorCompilation_ - Disables Visual Studio's and FastBuild's multiprocessor compilation.
 * _NoRuntimeChecks_ - Disable Visual Studio's Basic Runtime Checks in Debug builds.

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -495,7 +495,11 @@
 			end
 		else
 			local tool = iif(cfg.language == "C", "CC", "CXX")
-			_p('  LINKCMD             = $(%s) -o $(TARGET) $(LINKOBJS) $(RESOURCES) $(ARCH) $(ALL_LDFLAGS) $(LIBS)', tool)
+			if (cfg.flags.NoLibGroups) then
+				_p('  LINKCMD             = $(%s) -o $(TARGET) $(LINKOBJS) $(RESOURCES) $(ARCH) $(ALL_LDFLAGS) $(LIBS)', tool)
+			else
+				_p('  LINKCMD             = $(%s) -o $(TARGET) $(LINKOBJS) $(RESOURCES) $(ARCH) $(ALL_LDFLAGS) -Wl,--start-group $(LIBS) -Wl,--end-group', tool)
+			end
 		end
 	end
 

--- a/src/actions/ninja/ninja_cpp.lua
+++ b/src/actions/ninja/ninja_cpp.lua
@@ -66,7 +66,11 @@ local p     = premake
 
 		local link = iif(cfg.language == "C", tool.cc, tool.cxx)
 		_p("rule link")
-		_p("  command = $pre_link " .. link .. " -o $out @$out.rsp $all_ldflags $libs $post_build")
+		if (cfg.flags.NoLibGroups) then
+			_p("  command = $pre_link " .. link .. " -o $out @$out.rsp $all_ldflags $libs $post_build")
+		else
+			_p("  command = $pre_link " .. link .. " -o $out @$out.rsp $all_ldflags -Wl,--start-group $libs -Wl,--end-group $post_build")
+		end
 		_p("  rspfile = $out.rsp")
   		_p("  rspfile_content = $all_outputfiles")
 		_p("  description = link $out")

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -217,6 +217,7 @@
 					NoImportLib = 1,
 					NoIncrementalLink = 1,
 					NoJMC = 1,
+					NoLibGroups = 1,
 					NoManifest = 1,
 					NoMultiProcessorCompilation = 1,
 					NoNativeWChar = 1,


### PR DESCRIPTION
Hi,

this PR adds `-Wl,--start-group` and `-Wl,--end-group` around `$(LIBS)` in the makefile LINKCMD.
This forces the linker to iterate over the provided libs until no further symbol can be resolved. (This is default behavior in VS and Xcode, but was missing for make and ninja).

Wrapping is the new default behavior for make and ninja, but it can be disabled with the flag 'NoLibGroups' if some exotic linker does not understand it.

Cheers.

close GENie/issues/435