### PR TITLE
Add circular libs resolving to Makefile and ninja

### DIFF
--- a/docs/scripting-reference.md
+++ b/docs/scripting-reference.md
@@ -637,6 +637,7 @@ _flags_ - List of flag names from list below. Names are case-insensitive and ign
 * _FloatFast_ - Enable floating point optimizations at the expense of accuracy.
 * _FloatStrict_ - Improve floating point consistency at the expense of performance.
 * _FullSymbols_ - Use together with _Symbols_ to generate full debug symbols with Visual Studio.
+* _LinkSupportCircularDependencies_ - Enables the linker to iterate over provided libs in order to resolve circular dependencies (make and ninja only).
 * _Managed_ - Enable Managed C++ (.NET).
 * _MinimumWarnings_ - - Sets compiler's minimum warning level (Visual Studio only).
 * _MFC_ - Enable support for Microsoft Foundation Classes.

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -495,7 +495,13 @@
 			end
 		else
 			local tool = iif(cfg.language == "C", "CC", "CXX")
-			_p('  LINKCMD             = $(%s) -o $(TARGET) $(LINKOBJS) $(RESOURCES) $(ARCH) $(ALL_LDFLAGS) $(LIBS)', tool)
+			local startgroup = ''
+			local endgroup = ''
+			if (cfg.flags.LinkSupportCircularDependencies) then
+				startgroup = '-Wl,--start-group'
+				endgroup = '-Wl,--end-group'
+			end
+			_p('  LINKCMD             = $(%s) -o $(TARGET) $(LINKOBJS) $(RESOURCES) $(ARCH) $(ALL_LDFLAGS) %s $(LIBS) %s', tool, startgroup, endgroup)
 		end
 	end
 

--- a/src/actions/ninja/ninja_cpp.lua
+++ b/src/actions/ninja/ninja_cpp.lua
@@ -66,7 +66,13 @@ local p     = premake
 
 		local link = iif(cfg.language == "C", tool.cc, tool.cxx)
 		_p("rule link")
-		_p("  command = $pre_link " .. link .. " -o $out @$out.rsp $all_ldflags $libs $post_build")
+		local startgroup = ''
+		local endgroup = ''
+		if (cfg.flags.LinkSupportCircularDependencies) then
+			startgroup = '-Wl,--start-group'
+			endgroup = '-Wl,--end-group'
+		end
+		_p("  command = $pre_link " .. link .. " -o $out @$out.rsp $all_ldflags %s $libs %s $post_build", startgroup, endgroup)
 		_p("  rspfile = $out.rsp")
   		_p("  rspfile_content = $all_outputfiles")
 		_p("  description = link $out")

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -206,6 +206,7 @@
 					FloatStrict = 1,
 					FullSymbols = 1,
 					Hotpatchable = 1,
+					LinkSupportCircularDependencies = 1,
 					Managed = 1,
 					MinimumWarnings = 1,
 					MFC = 1,


### PR DESCRIPTION
Hi,

so this is the revised version of the `-Wl,--start-group` et al. patch, made for #435.
This time, it's entirely optional.

Just to be safe, what compiler/platform should I test it with?
(I've tested it with my own large projects, but that's only targeting Android).

Cheers.
