### PR TITLE
Fix crash when encountering node with empty config

### DIFF
--- a/src/actions/cmake/cmake_project.lua
+++ b/src/actions/cmake/cmake_project.lua
@@ -50,8 +50,11 @@ function cmake.files(prj)
         onbranchexit = function(node, depth)
         end,
         onleaf = function(node, depth)
-            table.insert(ret, node.cfg.name)
-            _p(1, '../%s', node.cfg.name)
+            assert(node, "unexpected empty node")
+            if node.cfg then
+                table.insert(ret, node.cfg.name)
+                _p(1, '../%s', node.cfg.name)
+            end
         end,
     }, true, 1)
 


### PR DESCRIPTION
Hi,

I ran into the issue that the cmake generator was crashing on some nodes that had no cfg field.
This fixes it.

Cheers.