### PR TITLE
[makefile projgen] allow to change project type

### DIFF
--- a/makefile
+++ b/makefile
@@ -25,37 +25,38 @@ endif
 .PHONY: release
 
 GENIE=bin/$(OS)/genie
+PROJECT_TYPE?=gmake
 
 SILENT?=@
 
 $(GENIE):
-	$(SILENT) $(MAKE) -C build/gmake.$(OS)
+	$(SILENT) $(MAKE) -C build/$(PROJECT_TYPE).$(OS)
 
 all: $(SILENT) $(GENIE)
 
 clean:
-	$(SILENT) $(MAKE) -C build/gmake.$(OS) clean
+	$(SILENT) $(MAKE) -C build/$(PROJECT_TYPE).$(OS) clean
 	$(SILENT) -rm -rf bin
 
 projgen:
-	$(SILENT) $(GENIE) --to=../build/gmake.windows --os=windows gmake
-	$(SILENT) $(GENIE) --to=../build/gmake.linux   --os=linux gmake
-	$(SILENT) $(GENIE) --to=../build/gmake.darwin  --os=macosx --platform=universal32 gmake
-	$(SILENT) $(GENIE) --to=../build/gmake.freebsd --os=bsd gmake
+	$(SILENT) $(GENIE) --to=../build/$(PROJECT_TYPE).windows --os=windows $(PROJECT_TYPE)
+	$(SILENT) $(GENIE) --to=../build/$(PROJECT_TYPE).linux   --os=linux $(PROJECT_TYPE)
+	$(SILENT) $(GENIE) --to=../build/$(PROJECT_TYPE).darwin  --os=macosx --platform=universal32 $(PROJECT_TYPE)
+	$(SILENT) $(GENIE) --to=../build/$(PROJECT_TYPE).freebsd --os=bsd $(PROJECT_TYPE)
 
 rebuild:
-	$(SILENT) $(MAKE) -C build/gmake.$(OS) clean all
+	$(SILENT) $(MAKE) -C build/$(PROJECT_TYPE).$(OS) clean all
 
 release-windows release-darwin: $(GENIE)
 	$(GENIE) release
-	$(SILENT) $(MAKE) -C build/gmake.$(OS) clean all
+	$(SILENT) $(MAKE) -C build/$(PROJECT_TYPE).$(OS) clean all
 	$(SILENT) git checkout src/host/version.h
 
 release-linux: $(GENIE)
 	$(SILENT) $(GENIE) release
-	$(SILENT) $(MAKE) -C build/gmake.darwin  clean all CC=x86_64-apple-darwin15-clang
-	$(SILENT) $(MAKE) -C build/gmake.linux   clean all
-	$(SILENT) $(MAKE) -C build/gmake.windows clean all CC=x86_64-w64-mingw32-gcc
+	$(SILENT) $(MAKE) -C build/$(PROJECT_TYPE).darwin  clean all CC=x86_64-apple-darwin15-clang
+	$(SILENT) $(MAKE) -C build/$(PROJECT_TYPE).linux   clean all
+	$(SILENT) $(MAKE) -C build/$(PROJECT_TYPE).windows clean all CC=x86_64-w64-mingw32-gcc
 	$(SILENT) git checkout src/host/version.h
 
 release: release-$(OS)


### PR DESCRIPTION
Hi @bkaradzic,

This PR makes the makefile more flexible in such as it allows to generate different project types to build GENie.
I.e. by setting $(PROJECT_TYPE) to e.g. `ninja` on the command, the `projgen` rule will generate ninja files instead of the gmake ones, and the `release` rule will build using ninja.

This was actually just a test I did locally, but if figures, it speeds up the build by factor 6 (12s build time go down to 2s), so I figured I might as well send a PR for it.

Note that the default value for $(PROJECT_TYPE) is `gmake`, so nothing will change unless using this option.

Cheers.

---
description from the single change below:
```
Change makerules to take variable $(PROJECT_TYPE)
instead of hardcoded 'gmake'

This allows to run `make projgen PROJECT_TYPE=ninja` to generate ninja build files instead.
and to build GENie using ninja by running `make release PROJECT_TYPE=ninja`.

Using ninja improves build times,
e.g. for macOS: 12.47s with gmake goes down to 2.05s with ninja.
```