### PR TITLE
Wholearchive fixup for macos

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -278,6 +278,8 @@
 	function premake.gcc.wholearchive(lib)
 		if premake.gcc.llvm then
 			return {"-force_load", lib}
+		elseif os.get() == "macosx" then
+			return {"-Wl,-force_load", lib}
 		else
 			return {"-Wl,--whole-archive", lib, "-Wl,--no-whole-archive"}
 		end


### PR DESCRIPTION
Hi,

this is a supplementary PR for #485 which fixes an issue I encountered when building on OSX, namely that `ld` does not support the `--whole-archive` argument.

Cheers.