### PR TITLE
Make description of 'Kind::WindowedApp' clearer.

### DIFF
--- a/docs/scripting-reference.md
+++ b/docs/scripting-reference.md
@@ -903,7 +903,7 @@ Sets the kind of binary object being created by the project, such as a console o
 _kind_ - project kind identifier. One of:
 
 * _ConsoleApp_ - console executable
-* _WindowedApp_ - application that runs in a desktop window. Does not apply on Linux.
+* _WindowedApp_ - application that runs in a window (Windows, Android, MacOS and iOS). Does not apply on Linux.
 * _StaticLib_ - static library
 * _SharedLib_ - shared library or DLL
 * _Bundle_ - Xcode: Cocoa Bundle, everywhere else: alias to _SharedLib_


### PR DESCRIPTION
As it stood, I misinterpreted the description to only hold for *desktop* apps.
I therefore thought that my iOS project's kind would be 'Bundle', but that's
not correct.

I've tried to avoid any disambiguity in the new description for
'WindowedApp'.

 On branch master