### PR TITLE
Fix incorrect prebuild dependency being used in Ninja c++ link targets

### DIFF
--- a/src/actions/ninja/ninja_cpp.lua
+++ b/src/actions/ninja/ninja_cpp.lua
@@ -331,7 +331,7 @@ end
 
 	function cpp.linker(prj, cfg, objfiles, tool)
 		local all_ldflags    = ninja.list(table.join(tool.getlibdirflags(cfg), tool.getldflags(cfg), cfg.linkoptions))
-		local prebuildsuffix = #cfg.prebuildcommands > 0 and "||__prebuildcommands" or ""
+		local prebuildsuffix = #cfg.prebuildcommands > 0 and ("||__prebuildcommands_" .. premake.esc(prj.name)) or ""
 		local libs           = {}
 		local walibs         = {}
 		local lddeps         = {}


### PR DESCRIPTION
Missed one place when adding the suffix to __prebuildcommands. Didn't discover it until trying to use Ninja on Windows for some reason.