### PR TITLE
[Ninja] make responsefiles optional

### DIFF
--- a/docs/scripting-reference.md
+++ b/docs/scripting-reference.md
@@ -671,8 +671,8 @@ _flags_ - List of flag names from list below. Names are case-insensitive and ign
 * _Unsafe_ - Enable the use of unsafe code in .NET applications.
 * _UnsignedChar_ - Force `char`s to be `unsigned` by default.
 * _UseFullPaths_ - Enable absolute paths for `__FILE__`. 
-* _UseLDResponseFile_ - Enable use of response file (aka @file) for linking lib dependencies (make only).
-* _UseObjectResponseFile_ - Enable use of response file (aka @file) for linking objects (make only).
+* _UseLDResponseFile_ - Enable use of response file (aka @file) for linking lib dependencies (make and ninja).
+* _UseObjectResponseFile_ - Enable use of response file (aka @file) for linking objects (make and ninja).
 * _WinMain_ - Use WinMain() as the entry point for Windows applications, rather than main().
 
 **Note:** When not set, options will default to the tool default.

--- a/src/actions/ninja/ninja_cpp.lua
+++ b/src/actions/ninja/ninja_cpp.lua
@@ -89,11 +89,19 @@ end
 			startgroup = '-Wl,--start-group'
 			endgroup = '-Wl,--end-group'
 		end
-		_p("  command         = " .. wrap_ninja_cmd("$pre_link " .. link .. " -o $out @$out.rsp $all_ldflags $post_build"))
-		_p("  description     = link $out")
-		_p("  rspfile         = $out.rsp")
-		_p("  rspfile_content = $all_outputfiles $walibs" .. string.format("%s $libs %s", startgroup, endgroup))
-		_p("")
+
+		local rspfile_content = "$all_outputfiles $walibs" .. string.format("%s $libs %s", startgroup, endgroup)
+		if cfg.flags.UseLDResponseFile then
+			_p("  command         = " .. wrap_ninja_cmd("$pre_link " .. link .. " -o $out @$out.rsp $all_ldflags $post_build"))
+			_p("  description     = link $out")
+			_p("  rspfile         = $out.rsp")
+			_p("  rspfile_content = %s", rspfile_content)
+			_p("")
+		else
+			_p("  command         = " .. wrap_ninja_cmd("$pre_link " .. link .. " -o $out " .. rspfile_content .. " $all_ldflags $post_build"))
+			_p("  description     = link $out")
+			_p("")
+		end
 
 		_p("rule exec")
 		_p("  command     = " .. wrap_ninja_cmd("$command"))

--- a/src/actions/ninja/ninja_cpp.lua
+++ b/src/actions/ninja/ninja_cpp.lua
@@ -53,7 +53,6 @@ end
 		}
 
 		_p("")
-
 		_p("# core rules for " .. cfg.name)
 		_p("rule cc")
 		_p("  command     = " .. wrap_ninja_cmd(tool.cc .. " $defines $includes $flags -MMD -MF $out.d -c -o $out $in"))
@@ -67,12 +66,20 @@ end
 		_p("  depfile     = $out.d")
 		_p("  deps        = gcc")
 		_p("")
-		_p("rule ar")
-		_p("  command         = " .. wrap_ninja_cmd(tool.ar .. " $flags $out @$out.rsp " .. (os.is("MacOSX") and " 2>&1 > /dev/null | sed -e '/.o) has no symbols$$/d'" or "")))
-		_p("  description     = ar $out")
-		_p("  rspfile         = $out.rsp")
-		_p("  rspfile_content = $in $libs")
-		_p("")
+
+		if cfg.flags.UseObjectResponseFile then
+			_p("rule ar")
+			_p("  command         = " .. wrap_ninja_cmd(tool.ar .. " $flags $out @$out.rsp " .. (os.is("MacOSX") and " 2>&1 > /dev/null | sed -e '/.o) has no symbols$$/d'" or "")))
+			_p("  description     = ar $out")
+			_p("  rspfile         = $out.rsp")
+			_p("  rspfile_content = $in $libs")
+			_p("")
+		else
+			_p("rule ar")
+			_p("  command         = " .. wrap_ninja_cmd(tool.ar .. " $flags $out $in $libs" .. (os.is("MacOSX") and " 2>&1 > /dev/null | sed -e '/.o) has no symbols$$/d'" or "")))
+			_p("  description     = ar $out")
+			_p("")
+		end
 
 		local link = iif(cfg.language == "C", tool.cc, tool.cxx)
 		_p("rule link")


### PR DESCRIPTION
This is a fix for #498. 
It makes the usage of responsefiles in ninja optional and dependent on the flags `UseObjectResponseFile` (for linking objects, i.e. calling `ar`) and `UseLDResponseFile` (for linking DLLs or executables, i.e. calling `ld`).

This allows to set the flags by default, and disable them specifically for `configuration { "ninja", "osx" }`

