### PR TITLE
Fix premake_locate on linux

### DIFF
--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -130,6 +130,8 @@ int premake_locate(lua_State* L, const char* argv0)
 	char buffer[PATH_MAX];
 	const char* path = NULL;
 
+	memset(buffer, 0, PATH_MAX);
+
 #if PLATFORM_WINDOWS
 	DWORD len = GetModuleFileName(NULL, buffer, PATH_MAX);
 	if (len > 0)


### PR DESCRIPTION
Discovered on Ubuntu 20.04, readlink() as per the documentation is not required to null-terminate the provided string. As a result, scripts using _PREMAKE_COMMAND in build commands can occasionally produce invalid characters in generated files.