### PR TITLE
Add vs2022 to summary at the top of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Supported project generators:
  * GNU Makefile
  * [JSON Compilation Database][jcdb]
  * Ninja (experimental)
- * Visual Studio 2010, 2012, 2013, 2015, 2017, 2019
+ * Visual Studio 2010, 2012, 2013, 2015, 2017, 2019, 2022
  * XCode
 
 Download (stable)


### PR DESCRIPTION
(added to changelog lower in the file in pull request #536)

People reading quickly might stop at the summary and assume vs2022 is not supported.