### PR TITLE
Fix bad index in removevalues

### DIFF
--- a/src/base/bake.lua
+++ b/src/base/bake.lua
@@ -166,7 +166,7 @@
 		for i = #tbl, 1, -1 do
 			for _, pattern in ipairs(removes) do
 				if pattern == tbl[i] then
-					table.remove(tbl, k)
+					table.remove(tbl, i)
 				end
 			end
 		end


### PR DESCRIPTION
When the table.remove call from split into its own reverse iterating loop, the table.remove call was still using the `k` variable from the old loop rather than the new `i` index.