### PR TITLE
use gmake file function for response files

### DIFF
--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -584,15 +584,13 @@
 
 		_p('ifneq (,$(OBJRESP))')
 		_p('$(OBJRESP): $(OBJECTS) | $(TARGETDIR) $(OBJDIRS)')
-		_p('\t$(SILENT) echo $^')
-		_p('\t$(SILENT) echo $^ > $@')
+		_p('\t$(file >$@,$^)')
 		_p('endif')
 		_p('')
 
 		_p('ifneq (,$(LDRESP))')
 		_p('$(LDRESP): $(LDDEPS) | $(TARGETDIR) $(OBJDIRS)')
-		_p('\t$(SILENT) echo $^')
-		_p('\t$(SILENT) echo $^ > $@')
+		_p('\t$(file >$@,$^)')
 		_p('endif')
 		_p('')
 

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -584,13 +584,19 @@
 
 		_p('ifneq (,$(OBJRESP))')
 		_p('$(OBJRESP): $(OBJECTS) | $(TARGETDIR) $(OBJDIRS)')
+		_p('\t$(info $@ $^)')
+		_p('ifeq (,$(findstring n,$(firstword -$(MAKEFLAGS))))')
 		_p('\t$(file >$@,$^)')
+		_p('endif')
 		_p('endif')
 		_p('')
 
 		_p('ifneq (,$(LDRESP))')
 		_p('$(LDRESP): $(LDDEPS) | $(TARGETDIR) $(OBJDIRS)')
+		_p('\t$(info $@ $^)')
+		_p('ifeq (,$(findstring n,$(firstword -$(MAKEFLAGS))))')
 		_p('\t$(file >$@,$^)')
+		_p('endif')
 		_p('endif')
 		_p('')
 


### PR DESCRIPTION
Current implementation relies on external `echo` command, which suffers from the same command line length limits the response files are designed to work around. The `file` function avoids this problem and theoretically performs better.