### PR TITLE
xcode: fix .storyboard support, alwaysOutOfDate for script phases, CONFIGURATION_BUILD_DIR bug

### DIFF
--- a/src/actions/xcode/xcode8.lua
+++ b/src/actions/xcode/xcode8.lua
@@ -45,11 +45,10 @@
 			options.CLANG_ENABLE_OBJC_ARC = "YES"
 		end
 
---		local outdir = path.getdirectory(cfg.buildtarget.directory)
---		if outdir ~= "." then
---			options.CONFIGURATION_BUILD_DIR = outdir
---		end
-		options.CONFIGURATION_BUILD_DIR = "$(SYSROOT)"
+		local outdir = path.getdirectory(cfg.buildtarget.directory)
+		if outdir ~= "." then
+			options.CONFIGURATION_BUILD_DIR = outdir
+		end
 
 		if tr.infoplist then
 			options.INFOPLIST_FILE = tr.infoplist.cfg.name

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -38,6 +38,7 @@
 			[".strings"] = "Resources",
 			[".nib"] = "Resources",
 			[".xib"] = "Resources",
+			[".storyboard"] = "Resources",
 			[".icns"] = "Resources",
 			[".bmp"] = "Resources",
 			[".wav"] = "Resources",
@@ -105,6 +106,7 @@
 			[".pch"]       = "sourcecode.c.h",
 			[".plist"]     = "text.plist.xml",
 			[".strings"]   = "text.plist.strings",
+			[".storyboard"] = "file.storyboard",
 			[".xib"]       = "file.xib",
 			[".icns"]      = "image.icns",
 			[".bmp"]       = "image.bmp",
@@ -152,6 +154,7 @@
 			[".pch"]       = "sourcecode.cpp.h",
 			[".plist"]     = "text.plist.xml",
 			[".strings"]   = "text.plist.strings",
+			[".storyboard"] = "file.storyboard",
 			[".xib"]       = "file.xib",
 			[".icns"]      = "image.icns",
 			[".bmp"]       = "image.bmp",
@@ -926,6 +929,7 @@ end
 						end
 					end
 					_p(3,');');
+					_p(3,'alwaysOutOfDate = 1;');
 					_p(3,'name = %s;', name);
 					_p(3,'outputPaths = (');
 					_p(3,');');


### PR DESCRIPTION
## Summary

Three independent Xcode generator bugs discovered while using GENie with an iOS/macOS project on Xcode 15+.

---

### 1. `.storyboard` files not added to Resources build phase

**Files:** `xcode_common.lua` — `getbuildcategory`, `getfiletype`, `getfiletypeForced`

The extension tables know `.xib` but not `.storyboard`. As a result, storyboard files receive `lastKnownFileType = text` and are **never added to `PBXResourcesBuildPhase`**, so they are missing from the compiled app bundle at runtime.

**Fix:** add `[".storyboard"] = "Resources"` to `getbuildcategory` and `[".storyboard"] = "file.storyboard"` to both `getfiletype` and `getfiletypeForced`.

---

### 2. `PBXShellScriptBuildPhase` missing `alwaysOutOfDate`

**File:** `xcode_common.lua` — `PBXShellScriptBuildPhase`

Xcode 15+ warns for every script phase that has no `outputPaths`:

> "Run script build phase 'Postbuild' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking 'Based on dependency analysis' in the script phase."

The correct fix per Xcode documentation is to emit `alwaysOutOfDate = 1` in the phase definition. GENie never emits this key.

**Fix:** add `_p(3,'alwaysOutOfDate = 1;')` before the `name` line in `doblock`.

---

### 3. `CONFIGURATION_BUILD_DIR = "$(SYSROOT)"` in `xcode8.lua`

**File:** `xcode8.lua` — `XCBuildConfiguration_Target`

`SYSROOT` expands to the **SDK path** (e.g. `.../iPhoneOS18.4.sdk`), not a build output directory. Setting `CONFIGURATION_BUILD_DIR` to it causes Xcode to report **"executable path is null"** for `WindowedApp` targets that have no explicit `targetdir`.

The original code (still present, commented out) correctly used `outdir` when it was non-trivial. The replacement with `$(SYSROOT)` appears to be an incomplete refactor.

**Fix:** restore the original conditional logic — only set `CONFIGURATION_BUILD_DIR` when `outdir ~= "."`.

Made with [Cursor](https://cursor.com)