### PR TITLE
xcode: add xcodepostbuildinputs/xcodepostbuildoutputs API for Postbuild script phase

### DIFF
--- a/src/actions/xcode/xcode8.lua
+++ b/src/actions/xcode/xcode8.lua
@@ -45,11 +45,10 @@
 			options.CLANG_ENABLE_OBJC_ARC = "YES"
 		end
 
---		local outdir = path.getdirectory(cfg.buildtarget.directory)
---		if outdir ~= "." then
---			options.CONFIGURATION_BUILD_DIR = outdir
---		end
-		options.CONFIGURATION_BUILD_DIR = "$(SYSROOT)"
+		local outdir = path.getdirectory(cfg.buildtarget.directory)
+		if outdir ~= "." then
+			options.CONFIGURATION_BUILD_DIR = outdir
+		end
 
 		if tr.infoplist then
 			options.INFOPLIST_FILE = tr.infoplist.cfg.name

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -38,6 +38,7 @@
 			[".strings"] = "Resources",
 			[".nib"] = "Resources",
 			[".xib"] = "Resources",
+			[".storyboard"] = "Resources",
 			[".icns"] = "Resources",
 			[".bmp"] = "Resources",
 			[".wav"] = "Resources",
@@ -105,6 +106,7 @@
 			[".pch"]       = "sourcecode.c.h",
 			[".plist"]     = "text.plist.xml",
 			[".strings"]   = "text.plist.strings",
+			[".storyboard"] = "file.storyboard",
 			[".xib"]       = "file.xib",
 			[".icns"]      = "image.icns",
 			[".bmp"]       = "image.bmp",
@@ -152,6 +154,7 @@
 			[".pch"]       = "sourcecode.cpp.h",
 			[".plist"]     = "text.plist.xml",
 			[".strings"]   = "text.plist.strings",
+			[".storyboard"] = "file.storyboard",
 			[".xib"]       = "file.xib",
 			[".icns"]      = "image.icns",
 			[".bmp"]       = "image.bmp",
@@ -926,6 +929,7 @@ end
 						end
 					end
 					_p(3,');');
+					_p(3,'alwaysOutOfDate = 1;');
 					_p(3,'name = %s;', name);
 					_p(3,'outputPaths = (');
 					_p(3,');');

--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -905,7 +905,7 @@ end
 	function xcode.PBXShellScriptBuildPhase(tr)
 		local wrapperWritten = false
 
-		local function doblock(id, name, commands, files)
+		local function doblock(id, name, commands, inputfiles, outputfiles)
 			if commands ~= nil then
 				commands = table.flatten(commands)
 			end
@@ -920,18 +920,28 @@ end
 					_p(3,'files = (')
 					_p(3,');')
 					_p(3,'inputPaths = (');
-					if files ~= nil then
-						files = table.flatten(files)
-						if #files > 0 then
-							for _, file in ipairs(files) do
+					if inputfiles ~= nil then
+						inputfiles = table.flatten(inputfiles)
+						if #inputfiles > 0 then
+							for _, file in ipairs(inputfiles) do
 								_p(4, '"%s",', file)
 							end
 						end
 					end
 					_p(3,');');
-					_p(3,'alwaysOutOfDate = 1;');
+					if outputfiles == nil or #table.flatten(outputfiles) == 0 then
+						_p(3,'alwaysOutOfDate = 1;');
+					end
 					_p(3,'name = %s;', name);
 					_p(3,'outputPaths = (');
+					if outputfiles ~= nil then
+						outputfiles = table.flatten(outputfiles)
+						if #outputfiles > 0 then
+							for _, file in ipairs(outputfiles) do
+								_p(4, '"%s",', file)
+							end
+						end
+					end
 					_p(3,');');
 					_p(3,'runOnlyForDeploymentPostprocessing = 0;');
 					_p(3,'shellPath = /bin/sh;');
@@ -954,9 +964,10 @@ end
 			return commands
 		end
 
-		local function dobuildblock(id, name, which)
+		local function dobuildblock(id, name, which, inputswhich, outputswhich)
 			-- see if there are any commands to add for each config
 			local commands = {}
+			local inputfiles, outputfiles
 			for _, cfg in ipairs(tr.configs) do
 				local cfgcmds = wrapcommands(cfg[which], cfg)
 				if #cfgcmds > 0 then
@@ -964,8 +975,14 @@ end
 						table.insert(commands, cmd)
 					end
 				end
+				if inputswhich and cfg[inputswhich] and #cfg[inputswhich] > 0 then
+					inputfiles = cfg[inputswhich]
+				end
+				if outputswhich and cfg[outputswhich] and #cfg[outputswhich] > 0 then
+					outputfiles = cfg[outputswhich]
+				end
 			end
-			doblock(id, name, commands)
+			doblock(id, name, commands, inputfiles, outputfiles)
 		end
 
 		local function doscriptphases(which)
@@ -989,7 +1006,7 @@ end
 
 		dobuildblock("9607AE1010C857E500CD1376", "Prebuild", "prebuildcommands")
 		dobuildblock("9607AE3510C85E7E00CD1376", "Prelink", "prelinkcommands")
-		dobuildblock("9607AE3710C85E8F00CD1376", "Postbuild", "postbuildcommands")
+		dobuildblock("9607AE3710C85E8F00CD1376", "Postbuild", "postbuildcommands", "xcodepostbuildinputs", "xcodepostbuildoutputs")
 		doscriptphases("xcodescriptphases")
 
 		if wrapperWritten then

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -1406,6 +1406,18 @@ end
 	}
 
 	newapifield {
+		name  = "xcodepostbuildinputs",
+		kind  = "list",
+		scope = "config",
+	}
+
+	newapifield {
+		name  = "xcodepostbuildoutputs",
+		kind  = "list",
+		scope = "config",
+	}
+
+	newapifield {
 		name  = "xcodecopyresources",
 		kind  = "table",
 		scope = "project",


### PR DESCRIPTION
## Problem

GENie's `postbuildcommands` generates a `PBXShellScriptBuildPhase` with empty `inputPaths` and `outputPaths`. Xcode 15+ warns on every build:

> "Run script build phase 'Postbuild' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking 'Based on dependency analysis'."

The workaround in the previous PR (#594) was `alwaysOutOfDate = 1`, which silences the warning but means the script always runs even when nothing changed.

## Solution

Add two new Xcode-specific Lua API fields, mirroring the pattern of `xcodescriptphases`:

```lua
xcodepostbuildinputs  { ... }   -- fills inputPaths  for the Postbuild phase
xcodepostbuildoutputs { ... }   -- fills outputPaths for the Postbuild phase
```

When `xcodepostbuildoutputs` is non-empty, `alwaysOutOfDate` is **omitted** and Xcode uses its dependency analysis (stamp-file pattern). When no outputs are declared the previous `alwaysOutOfDate = 1` behaviour is preserved for full backward compatibility.

## Usage — stamp-file pattern

```lua
postbuildcommands {
    '"${SRCROOT}/../../scripts/copy_game_data.sh"'
}
-- Xcode skips the script entirely when runtime/ hasn't changed since last build.
xcodepostbuildinputs  { '"$(SRCROOT)/../../runtime/mundus/"' }
xcodepostbuildoutputs { '"$(DERIVED_FILE_DIR)/game_data.stamp"' }
```

The copy script creates the stamp at the end:
```bash
touch "${DERIVED_FILE_DIR}/game_data.stamp"
```

## Changes

- `src/base/api.lua` — register `xcodepostbuildinputs` (list) and `xcodepostbuildoutputs` (list)
- `src/actions/xcode/xcode_common.lua`:
  - `doblock` gains an `outputfiles` parameter, populates `outputPaths`, and only emits `alwaysOutOfDate` when no outputs are declared
  - `dobuildblock` gains `inputswhich`/`outputswhich` parameters and reads those config fields
  - Postbuild call passes `"xcodepostbuildinputs"` / `"xcodepostbuildoutputs"`

Made with [Cursor](https://cursor.com)